### PR TITLE
Stop reporting interface methods with @Test

### DIFF
--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
@@ -8,6 +8,7 @@ import com.linkedin.dex.spec.DexFile
 import java.io.File
 import java.io.FileInputStream
 import java.nio.ByteBuffer
+import java.nio.file.Files
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
@@ -34,7 +35,7 @@ class DexParser private constructor() {
 
             val allItems = Companion.findTestNames(apkPath)
 
-            java.nio.file.Files.write(File(outputPath + "/AllTests.txt").toPath(), allItems)
+            Files.write(File(outputPath + "/AllTests.txt").toPath(), allItems)
         }
 
         /**
@@ -65,7 +66,7 @@ class DexParser private constructor() {
                         .filter { it.name.endsWith(".dex") }
                         .map { zip.readBytes() }
                         .map { ByteBuffer.wrap(it) }
-                        .map { DexFile(it) }
+                        .map(::DexFile)
                         .toList()
             }
         }

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
@@ -4,6 +4,7 @@
  */
 package com.linkedin.dex.parser
 
+import com.linkedin.dex.spec.ACC_INTERFACE
 import com.linkedin.dex.spec.AnnotationItem
 import com.linkedin.dex.spec.AnnotationSetItem
 import com.linkedin.dex.spec.AnnotationsDirectoryItem
@@ -20,6 +21,7 @@ fun DexFile.findJUnit4Tests(): List<String> {
     val matchingItems: MutableList<String> = mutableListOf()
 
     classDefs.filter(::hasAnnotations)
+            .filterNot(::isInterface)
             .map { Pair(it, AnnotationsDirectoryItem.create(byteBuffer, it.annotationsOff)) }
             .map { Pair(it.first, it.second.methodAnnotations) }
             .map { Pair(it.first, getMethodsWithAnnotation(it.second, testAnnotationDescriptor)) }
@@ -46,6 +48,10 @@ fun DexFile.formatClassName(classDefItem: ClassDefItem): String {
     className += "#"
 
     return className
+}
+
+private fun isInterface(classDefItem: ClassDefItem): Boolean {
+    return classDefItem.accessFlags and ACC_INTERFACE == ACC_INTERFACE
 }
 
 private fun DexFile.getMethodsWithAnnotation(annotations: Array<MethodAnnotation>, targetDescriptor: String): List<String> {

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/AccessFlags.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/AccessFlags.kt
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.dex.spec
+
+const val ACC_PUBLIC = 0x1
+const val ACC_PRIVATE = 0x2
+const val ACC_PROTECTED = 0x4
+const val ACC_STATIC = 0x8
+const val ACC_FINAL = 0x10
+const val ACC_SYNCHRONIZED = 0x20
+const val ACC_VOLATILE = 0x40
+const val ACC_BRIDGE = 0x40
+const val ACC_TRANSIENT = 0x80
+const val ACC_VARARGS = 0x80
+const val ACC_NATIVE = 0x100
+const val ACC_INTERFACE = 0x200
+const val ACC_ABSTRACT = 0x400
+const val ACC_STRICT = 0x800
+const val ACC_SYNTHETIC = 0x1000
+const val ACC_ANNOTATION = 0x2000
+const val ACC_ENUM = 0x4000
+const val ACC_CONSTRUCTOR = 0x10000
+const val ACC_DECLARED_SYNCHRONIZED = 0x20000


### PR DESCRIPTION
Interface methods (in either Kotlin or Java) which
are annotated with @Test are not valid JUnit 4 tests,
so dex-test-parser shouldn't be reporting them in the
list of tests in an apk.

Fixes #3