### PR TITLE
Add support for parsing and reading encoded values

### DIFF
--- a/parser/ValidTestList.txt
+++ b/parser/ValidTestList.txt
@@ -7,6 +7,7 @@ com.linkedin.parser.test.junit3.kotlin.KotlinJUnit3AndroidTestCase#testKotlinJUn
 com.linkedin.parser.test.junit3.kotlin.KotlinJUnit3TestInsideStaticInnerClass$InnerClass#testKotlinJUnit3TestInsideStaticInnerClass
 com.linkedin.parser.test.junit3.kotlin.KotlinJUnit3WithAnnotations#testKotlinJUnit3WithAnnotations
 com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4
+com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJunit4Second
 com.linkedin.parser.test.junit4.java.JUnit4ClassInsideInterface$InnerClass#innerClassTest
 com.linkedin.parser.test.junit4.java.JUnit4TestInsideStaticInnerClass$InnerClass#innerClassTest
 com.linkedin.parser.test.junit4.kotlin.KotlinJUnit4Basic#testKotlinJUnit4Basic

--- a/parser/ValidTestList.txt
+++ b/parser/ValidTestList.txt
@@ -7,7 +7,7 @@ com.linkedin.parser.test.junit3.kotlin.KotlinJUnit3AndroidTestCase#testKotlinJUn
 com.linkedin.parser.test.junit3.kotlin.KotlinJUnit3TestInsideStaticInnerClass$InnerClass#testKotlinJUnit3TestInsideStaticInnerClass
 com.linkedin.parser.test.junit3.kotlin.KotlinJUnit3WithAnnotations#testKotlinJUnit3WithAnnotations
 com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4
-com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJunit4Second
+com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second
 com.linkedin.parser.test.junit4.java.JUnit4ClassInsideInterface$InnerClass#innerClassTest
 com.linkedin.parser.test.junit4.java.JUnit4TestInsideStaticInnerClass$InnerClass#innerClassTest
 com.linkedin.parser.test.junit4.kotlin.KotlinJUnit4Basic#testKotlinJUnit4Basic

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -95,3 +95,13 @@ task testParsing(dependsOn: ':test-app:assembleDebugAndroidTest', type: JavaExec
     }
 }
 check.dependsOn testParsing
+
+// Configure the jvm tests so that apk will be present and in a consistent location
+// When you run from the IDE, the working directory is different than when running through gradle
+// To make sure we can run tests from either the IDE or gradle directly, we set it to be the same as IDE settings
+// We also need to make sure the test apk is generated as part of the compile task, so the tests have their
+// dependencies fulfilled
+testClasses.dependsOn ':test-app:assembleDebugAndroidTest'
+test {
+    workingDir project.getRootProject().getProjectDir()
+}

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DecodedValue.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DecodedValue.kt
@@ -1,0 +1,58 @@
+package com.linkedin.dex.parser
+
+import com.linkedin.dex.spec.DexFile
+import com.linkedin.dex.spec.EncodedValue
+import com.linkedin.dex.spec.Leb128
+
+/**
+ * A sealed class to represent the decoded values of an EncodedValue object.
+ */
+// TODO: Add support for complex types
+sealed class DecodedValue {
+    data class DecodedByte(val value: Byte) : DecodedValue()
+    data class DecodedShort(val value: Short) : DecodedValue()
+    data class DecodedChar(val value: Char) : DecodedValue()
+    data class DecodedInt(val value: Int) : DecodedValue()
+    data class DecodedLong(val value: Long) : DecodedValue()
+    data class DecodedFloat(val value: Float) : DecodedValue()
+    data class DecodedDouble(val value: Double) : DecodedValue()
+    // Value is an index into the string table
+    data class DecodedString(val value: String) : DecodedValue()
+
+    data class DecodedType(val value: String) : DecodedValue()
+    class DecodedNull : DecodedValue()
+    data class DecodedBoolean(val value: Boolean) : DecodedValue()
+    
+    companion object {
+        /**
+         * Resolve an encoded value against the given dexfile
+         */
+        fun createFromDecodedValue(dexFile: DexFile, encodedValue: EncodedValue): DecodedValue {
+            when (encodedValue) {
+                is EncodedValue.EncodedByte -> return DecodedByte(encodedValue.value)
+                is EncodedValue.EncodedShort -> return DecodedShort(encodedValue.value)
+                is EncodedValue.EncodedChar -> return DecodedChar(encodedValue.value)
+                is EncodedValue.EncodedInt -> return DecodedInt(encodedValue.value)
+                is EncodedValue.EncodedLong -> return DecodedLong(encodedValue.value)
+                is EncodedValue.EncodedFloat -> return DecodedFloat(encodedValue.value)
+                is EncodedValue.EncodedDouble -> return DecodedDouble(encodedValue.value)
+                is EncodedValue.EncodedString -> {
+                    dexFile.byteBuffer.position(dexFile.stringIds[encodedValue.value].stringDataOff)
+                    // read past unused size item
+                    Leb128.readUnsignedLeb128(dexFile.byteBuffer)
+                    return DecodedString(ParseUtils.parseStringBytes(dexFile.byteBuffer))
+                }
+                is EncodedValue.EncodedType -> {
+                    dexFile.byteBuffer.position(dexFile.typeIds[encodedValue.value].descriptorIdx)
+                    // read past unused size item
+                    Leb128.readUnsignedLeb128(dexFile.byteBuffer)
+                    return DecodedType(ParseUtils.parseStringBytes(dexFile.byteBuffer))
+                }
+                is EncodedValue.EncodedBoolean -> return DecodedBoolean(encodedValue.value)
+                is EncodedValue.EncodedNull -> return DecodedNull()
+
+                else -> return DecodedNull()
+            }
+        }
+    }
+}

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DecodedValue.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DecodedValue.kt
@@ -1,6 +1,8 @@
 package com.linkedin.dex.parser
 
 import com.linkedin.dex.spec.DexFile
+import com.linkedin.dex.spec.EncodedAnnotation
+import com.linkedin.dex.spec.EncodedArray
 import com.linkedin.dex.spec.EncodedValue
 import com.linkedin.dex.spec.Leb128
 
@@ -20,14 +22,20 @@ sealed class DecodedValue {
     data class DecodedString(val value: String) : DecodedValue()
 
     data class DecodedType(val value: String) : DecodedValue()
-    class DecodedNull : DecodedValue()
+    object DecodedNull : DecodedValue()
     data class DecodedBoolean(val value: Boolean) : DecodedValue()
+    // TODO: DecodedType
+    // TODO: DecodedField
+    // TODO: DecodedMethod
+    // TODO: DecodedEnum
+    // TODO: DecodedArrayValue
+    // TODO: DecodedAnnotationValue
     
     companion object {
         /**
          * Resolve an encoded value against the given dexfile
          */
-        fun createFromDecodedValue(dexFile: DexFile, encodedValue: EncodedValue): DecodedValue {
+        fun create(dexFile: DexFile, encodedValue: EncodedValue): DecodedValue {
             when (encodedValue) {
                 is EncodedValue.EncodedByte -> return DecodedByte(encodedValue.value)
                 is EncodedValue.EncodedShort -> return DecodedShort(encodedValue.value)
@@ -49,9 +57,9 @@ sealed class DecodedValue {
                     return DecodedType(ParseUtils.parseStringBytes(dexFile.byteBuffer))
                 }
                 is EncodedValue.EncodedBoolean -> return DecodedBoolean(encodedValue.value)
-                is EncodedValue.EncodedNull -> return DecodedNull()
+                is EncodedValue.EncodedNull -> return DecodedNull
 
-                else -> return DecodedNull()
+                else -> return DecodedNull
             }
         }
     }

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
@@ -10,7 +10,6 @@ import com.linkedin.dex.spec.ClassDefItem
 import com.linkedin.dex.spec.DexFile
 import com.linkedin.dex.spec.MethodIdItem
 
-
 /**
  * Find all methods that are annotated with JUnit4's @Test annotation
  */
@@ -19,7 +18,7 @@ fun DexFile.findJUnit4Tests(): List<TestMethod> {
     val classesWithAnnotations = classDefs.filter(::hasAnnotations).filterNot(::isInterface)
 
     return createTestMethods(classesWithAnnotations, findMethodIds())
-            .filter { it.annotationNames.contains(testAnnotationName) }
+            .filter { it.annotations.map { it.name }.contains(testAnnotationName) }
 }
 
 /**

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
@@ -18,7 +18,9 @@ fun DexFile.findJUnit4Tests(): List<TestMethod> {
     val classesWithAnnotations = classDefs.filter(::hasAnnotations).filterNot(::isInterface)
 
     return createTestMethods(classesWithAnnotations, findMethodIds())
-            .filter { it.annotations.map { it.name }.contains(testAnnotationName) }
+            .filter { it.annotations.map {
+                it.name
+            }.contains(testAnnotationName) }
 }
 
 /**

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/ParseUtils.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/ParseUtils.kt
@@ -4,7 +4,11 @@
  */
 package com.linkedin.dex.parser
 
-import com.linkedin.dex.spec.*
+import com.linkedin.dex.spec.ClassDefItem
+import com.linkedin.dex.spec.Leb128
+import com.linkedin.dex.spec.MethodIdItem
+import com.linkedin.dex.spec.StringIdItem
+import com.linkedin.dex.spec.TypeIdItem
 import java.nio.ByteBuffer
 import java.util.ArrayList
 

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/ParseUtils.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/ParseUtils.kt
@@ -4,11 +4,7 @@
  */
 package com.linkedin.dex.parser
 
-import com.linkedin.dex.spec.ClassDefItem
-import com.linkedin.dex.spec.Leb128
-import com.linkedin.dex.spec.MethodIdItem
-import com.linkedin.dex.spec.StringIdItem
-import com.linkedin.dex.spec.TypeIdItem
+import com.linkedin.dex.spec.*
 import java.nio.ByteBuffer
 import java.util.ArrayList
 

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/ParseUtils.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/ParseUtils.kt
@@ -37,6 +37,15 @@ object ParseUtils {
         return encodedName
     }
 
+    fun parseValueName(byteBuffer: ByteBuffer, stringIds: Array<StringIdItem>, nameIdx: Int): String {
+        val stringId = stringIds[nameIdx]
+        byteBuffer.position(stringId.stringDataOff)
+        // read past unused size item
+        Leb128.readUnsignedLeb128(byteBuffer)
+        val encodedName = parseStringBytes(byteBuffer)
+        return encodedName
+    }
+
     fun parseStringBytes(byteBuffer: ByteBuffer): String {
         val byteList = ArrayList<Byte>()
         do {

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/TestAnnotation.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/TestAnnotation.kt
@@ -1,0 +1,7 @@
+package com.linkedin.dex.parser
+
+/**
+ * A class to represent an annotation on method. Includes both the name of the annotation itself,
+ * and all of the values within it as a key-value map of name string to value
+ */
+data class TestAnnotation(val name: String, val values: Map<String, DecodedValue>)

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/AnnotationElement.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/AnnotationElement.kt
@@ -12,6 +12,6 @@ data class AnnotationElement(
 ) {
     constructor(byteBuffer: ByteBuffer) : this(
             nameIdx = Leb128.readUnsignedLeb128(byteBuffer),
-            value = EncodedValue(byteBuffer)
+            value = EncodedValue.getEncodedValue(byteBuffer)
     )
 }

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/AnnotationElement.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/AnnotationElement.kt
@@ -12,6 +12,6 @@ data class AnnotationElement(
 ) {
     constructor(byteBuffer: ByteBuffer) : this(
             nameIdx = Leb128.readUnsignedLeb128(byteBuffer),
-            value = EncodedValue.getEncodedValue(byteBuffer)
+            value = EncodedValue.create(byteBuffer)
     )
 }

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedArray.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedArray.kt
@@ -13,7 +13,7 @@ data class EncodedArray(
     companion object {
         fun create(byteBuffer: ByteBuffer): EncodedArray {
             val size = Leb128.readUnsignedLeb128(byteBuffer)
-            val values = Array(size, { EncodedValue.getEncodedValue(byteBuffer) })
+            val values = Array(size, { EncodedValue.create(byteBuffer) })
             return EncodedArray(size, values)
         }
     }

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedArray.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedArray.kt
@@ -13,7 +13,7 @@ data class EncodedArray(
     companion object {
         fun create(byteBuffer: ByteBuffer): EncodedArray {
             val size = Leb128.readUnsignedLeb128(byteBuffer)
-            val values = Array(size, { EncodedValue(byteBuffer) })
+            val values = Array(size, { EncodedValue.getEncodedValue(byteBuffer) })
             return EncodedArray(size, values)
         }
     }

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedValue.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedValue.kt
@@ -5,61 +5,95 @@
 package com.linkedin.dex.spec
 
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
-class EncodedValue(byteBuffer: ByteBuffer) {
-    val VALUE_BYTE: Byte = 0x00
-    val VALUE_SHORT: Byte = 0x02
-    val VALUE_CHAR: Byte = 0x03
-    val VALUE_INT: Byte = 0x04
-    val VALUE_LONG: Byte = 0x06
-    val VALUE_FLOAT: Byte = 0x10
-    val VALUE_DOUBLE: Byte = 0x11
-    val VALUE_STRING: Byte = 0x17
-    val VALUE_TYPE: Byte = 0x18
-    val VALUE_FIELD: Byte = 0x19
-    val VALUE_METHOD: Byte = 0x1a
-    val VALUE_ENUM: Byte = 0x1b
-    val VALUE_ARRAY: Byte = 0x1c
-    val VALUE_ANNOTATION: Byte = 0x1d
-    val VALUE_NULL: Byte = 0x1e
-    val VALUE_BOOLEAN: Byte = 0x1f
+sealed class EncodedValue {
+    data class EncodedByte(val value: Byte): EncodedValue()
+    data class EncodedShort(val value: Short): EncodedValue()
+    data class EncodedChar(val value: Char): EncodedValue()
+    data class EncodedInt(val value: Int): EncodedValue()
+    data class EncodedLong(val value: Long): EncodedValue()
+    data class EncodedFloat(val value: Float): EncodedValue()
+    data class EncodedDouble(val value: Double): EncodedValue()
+    // Value is an index into the string table
+    data class EncodedString(val value: Int): EncodedValue()
+    data class EncodedType(val value: Int): EncodedValue()
+    data class EncodedField(val value: Int): EncodedValue()
+    data class EncodedMethod(val value: Int): EncodedValue()
+    data class EncodedEnum(val value: Int): EncodedValue()
+    data class EncodedArrayValue(val value: EncodedArray): EncodedValue()
+    data class EncodedAnnotationValue(val value: EncodedAnnotation): EncodedValue()
+    class EncodedNull: EncodedValue()
+    data class EncodedBoolean(val value: Boolean): EncodedValue()
+    companion object {
+        val VALUE_BYTE: Byte = 0x00
+        val VALUE_SHORT: Byte = 0x02
+        val VALUE_CHAR: Byte = 0x03
+        val VALUE_INT: Byte = 0x04
+        val VALUE_LONG: Byte = 0x06
+        val VALUE_FLOAT: Byte = 0x10
+        val VALUE_DOUBLE: Byte = 0x11
+        val VALUE_STRING: Byte = 0x17
+        val VALUE_TYPE: Byte = 0x18
+        val VALUE_FIELD: Byte = 0x19
+        val VALUE_METHOD: Byte = 0x1a
+        val VALUE_ENUM: Byte = 0x1b
+        val VALUE_ARRAY: Byte = 0x1c
+        val VALUE_ANNOTATION: Byte = 0x1d
+        val VALUE_NULL: Byte = 0x1e
+        val VALUE_BOOLEAN: Byte = 0x1f
 
-    // ideally this should have a real type, but the test parser never uses this field so it's not necessary
-    val value: Any
+        fun getEncodedValue(byteBuffer: ByteBuffer): EncodedValue {
+            val argAndType = byteBuffer.get().toInt()
 
-    init {
-        val argAndType = byteBuffer.get().toInt()
+            // first three bits are the optional valueArg
+            val valueArg = (argAndType ushr 5).toByte()
+            // last five bits are the valueType
+            val valueType = (argAndType and 0x1F).toByte()
 
-        // first three bits are the optional valueArg
-        val valueArg = (argAndType ushr 5).toByte()
-        // last five bits are the valueType
-        val valueType = (argAndType and 0x1F).toByte()
-
-        when (valueType) {
-            VALUE_BYTE -> value = byteArrayOf(byteBuffer.get())
-            VALUE_SHORT -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_CHAR -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_INT -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_LONG -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_FLOAT -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_DOUBLE -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_STRING -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_TYPE -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_FIELD -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_METHOD -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_ENUM -> value = ByteArray(sizeOf(valueArg), { byteBuffer.get() })
-            VALUE_ARRAY -> value = EncodedArray.create(byteBuffer)
-            VALUE_ANNOTATION -> value = EncodedAnnotation.create(byteBuffer)
-            VALUE_NULL -> value = byteArrayOf()
-            VALUE_BOOLEAN -> value = byteArrayOf(valueArg)
-            else -> {
-                value = byteArrayOf()
-                throw DexException("Bad value type: " + valueType)
+            when (valueType) {
+                VALUE_BYTE -> return EncodedByte(byteBuffer.get())
+                VALUE_SHORT -> return EncodedShort(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 2).short)
+                VALUE_CHAR -> return EncodedChar(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 2).char)
+                VALUE_INT -> return EncodedInt(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).int)
+                VALUE_LONG -> return EncodedLong(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 8).long)
+                VALUE_FLOAT -> return EncodedFloat(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).float)
+                VALUE_DOUBLE -> return EncodedDouble(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 8).double)
+                VALUE_STRING -> return EncodedString(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).int)
+                VALUE_TYPE -> return EncodedType(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).int)
+                VALUE_FIELD -> return EncodedField(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).int)
+                VALUE_METHOD -> return EncodedMethod(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).int)
+                VALUE_ENUM -> return EncodedEnum(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).int)
+                VALUE_ARRAY -> return EncodedArrayValue(EncodedArray.create(byteBuffer))
+                VALUE_ANNOTATION -> return EncodedAnnotationValue(EncodedAnnotation.create(byteBuffer))
+                VALUE_NULL -> return EncodedNull()
+                VALUE_BOOLEAN -> return EncodedBoolean(valueArg.toInt() == 1)
+                else -> {
+                    throw DexException("Bad value type: " + valueType)
+                }
             }
         }
-    }
 
-    fun sizeOf(valueArg: Byte): Int {
-        return valueArg + 1
+        private fun sizeOf(valueArg: Byte): Int {
+            return valueArg + 1
+        }
+
+        private fun getPaddedBuffer(byteBuffer: ByteBuffer, size: Int, fullSize: Int): ByteBuffer {
+            val buffer = ByteBuffer.allocate(fullSize)
+            buffer.order(ByteOrder.LITTLE_ENDIAN)
+            var i = 0
+            while (i < size) {
+                i++
+                buffer.put(byteBuffer.get())
+            }
+            for (i in size+1..fullSize) {
+                buffer.put(0)
+            }
+
+            // Move to the start of the buffer so we can read values
+            buffer.position(0)
+
+            return buffer
+        }
     }
 }

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedValue.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedValue.kt
@@ -74,7 +74,7 @@ sealed class EncodedValue {
             }
         }
 
-        // The size of the field is generall represented as 1 more than the value of the first byte
+        // The size of the field is generaly represented as 1 more than the value of the first byte
         // See https://source.android.com/devices/tech/dalvik/dex-format#encoding
         private fun sizeOf(valueArg: Byte): Int {
             return valueArg + 1

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedValue.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedValue.kt
@@ -57,8 +57,8 @@ sealed class EncodedValue {
                 VALUE_CHAR -> return EncodedChar(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 2).char)
                 VALUE_INT -> return EncodedInt(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).int)
                 VALUE_LONG -> return EncodedLong(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 8).long)
-                VALUE_FLOAT -> return EncodedFloat(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).float)
-                VALUE_DOUBLE -> return EncodedDouble(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 8).double)
+                VALUE_FLOAT -> return EncodedFloat(getPaddedBufferToTheRight(byteBuffer, sizeOf(valueArg), 4).float)
+                VALUE_DOUBLE -> return EncodedDouble(getPaddedBufferToTheRight(byteBuffer, sizeOf(valueArg), 8).double)
                 VALUE_STRING -> return EncodedString(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).int)
                 VALUE_TYPE -> return EncodedType(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).int)
                 VALUE_FIELD -> return EncodedField(getPaddedBuffer(byteBuffer, sizeOf(valueArg), 4).int)
@@ -95,6 +95,29 @@ sealed class EncodedValue {
             for (x in size+1..fullSize) {
                 buffer.put(0)
             }
+
+            // Move to the start of the buffer so we can read values
+            buffer.position(0)
+
+            return buffer
+        }
+
+        // For float and double values, the value is padded to the right, so we need to build the buffer in the
+        // opposite order
+        private fun getPaddedBufferToTheRight(byteBuffer: ByteBuffer, size: Int, fullSize: Int): ByteBuffer {
+            val buffer = ByteBuffer.allocate(fullSize)
+            buffer.order(ByteOrder.LITTLE_ENDIAN)
+
+            for (x in size+1..fullSize) {
+                buffer.put(0)
+            }
+
+            var i = 0
+            while (i < size) {
+                i++
+                buffer.put(byteBuffer.get())
+            }
+
 
             // Move to the start of the buffer so we can read values
             buffer.position(0)

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -1,0 +1,240 @@
+package com.linkedin.dex
+
+import com.linkedin.dex.parser.DecodedValue
+import com.linkedin.dex.parser.DexParser
+import com.linkedin.dex.parser.TestMethod
+import org.junit.Assert
+import org.junit.Test
+import java.nio.file.Paths
+import java.util.logging.Level
+import java.util.logging.Logger
+
+class DexParserShould {
+    companion object {
+        val APK_PATH = "test-app/build/outputs/apk/test-app-debug-androidTest.apk"
+    }
+
+    @Test
+    fun parseCorrectNumberOfTestMethods() {
+        val testMethods = DexParser.findTestNames(APK_PATH)
+        Logger.getGlobal().log(Level.SEVERE, Paths.get("").toAbsolutePath().toString())
+
+        Assert.assertEquals(15, testMethods.size)
+    }
+
+    @Test
+    fun parseMethodWithMultipleMethodAnnotations() {
+        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
+
+        Assert.assertEquals(2, testMethods.size)
+
+        val method = testMethods.first()
+        Assert.assertEquals(method.testName, "com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4")
+        // TestValueAnnotation at the class level, Test annotation at the method level, and TestValueAnnotation at the method level
+        Assert.assertEquals(method.annotations.size, 3)
+    }
+
+    @Test
+    fun parseStringAnnotationValues() {
+        val method = getBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val classAnnotation = valueAnnotations.first()
+        val stringValue = classAnnotation.values["stringValue"]
+        Assert.assertNotNull(stringValue)
+        assertMatches(stringValue, "Hello world!")
+
+        val methodAnnotation = valueAnnotations[1]
+        val methodStringValue = methodAnnotation.values["stringValue"]
+        assertMatches(methodStringValue, "On a method")
+    }
+
+    @Test
+    fun parseIntAnnotationValues() {
+        val method = getBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val methodAnnotation = valueAnnotations[1]
+        val value = methodAnnotation.values["intValue"]
+        assertMatches(value, 12345)
+    }
+
+    @Test
+    fun parseBoolAnnotationValues() {
+        val method = getBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val methodAnnotation = valueAnnotations[1]
+        val value = methodAnnotation.values["boolValue"]
+        assertMatches(value, true)
+    }
+
+    @Test
+    fun parseLongAnnotationValues() {
+        val method = getBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val methodAnnotation = valueAnnotations[1]
+        val value = methodAnnotation.values["longValue"]
+        assertMatches(value, 56789L)
+    }
+
+    @Test
+    fun parseFloatAnnotationValues() {
+        val method = getSecondBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val methodAnnotation = valueAnnotations[1]
+        val value = methodAnnotation.values["floatValue"]
+        assertMatches(value, .25f)
+    }
+
+    @Test
+    fun parseDoubleAnnotationValues() {
+        val method = getSecondBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val methodAnnotation = valueAnnotations[1]
+        val value = methodAnnotation.values["doubleValue"]
+        assertMatches(value, .5)
+    }
+
+    @Test
+    fun parseByteAnnotationValues() {
+        val method = getSecondBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val methodAnnotation = valueAnnotations[1]
+        val value = methodAnnotation.values["byteValue"]
+        assertMatches(value, 0x0f.toByte())
+    }
+
+    @Test
+    fun parseCharAnnotationValues() {
+        val method = getSecondBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val methodAnnotation = valueAnnotations[1]
+        val value = methodAnnotation.values["charValue"]
+        assertMatches(value, '?')
+    }
+
+    @Test
+    fun parseShortAnnotationValues() {
+        val method = getSecondBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val methodAnnotation = valueAnnotations[1]
+        val value = methodAnnotation.values["shortValue"]
+        assertMatches(value, 3.toShort())
+    }
+
+    @Test
+    fun parseMultipleValuesInASingleAnnotation() {
+        val method = getBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val methodAnnotation = valueAnnotations[1]
+        assertMatches(methodAnnotation.values["stringValue"], "On a method")
+        assertMatches(methodAnnotation.values["intValue"], 12345)
+        assertMatches(methodAnnotation.values["boolValue"], true)
+        assertMatches(methodAnnotation.values["longValue"], 56789L)
+    }
+
+    private fun getBasicJunit4TestMethod(): TestMethod {
+        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4") }
+
+        Assert.assertEquals(1, testMethods.size)
+
+        val method = testMethods.first()
+        Assert.assertEquals(method.testName, "com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4")
+
+        return method
+    }
+
+    private fun getSecondBasicJunit4TestMethod(): TestMethod {
+        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second") }
+
+        Assert.assertEquals(1, testMethods.size)
+
+        val method = testMethods.first()
+        Assert.assertEquals(method.testName, "com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second")
+
+        return method
+    }
+
+    // region value type matchers
+    private fun assertMatches(value: DecodedValue?, string: String) {
+        if (value is DecodedValue.DecodedString) {
+            Assert.assertEquals(string, value.value)
+        } else {
+            throw Exception("Value was not a string type")
+        }
+    }
+
+    private fun assertMatches(value: DecodedValue?, number: Int) {
+        if (value is DecodedValue.DecodedInt) {
+            Assert.assertEquals(number, value.value)
+        } else {
+            throw Exception("Value was not an int type")
+        }
+    }
+
+    private fun assertMatches(value: DecodedValue?, bool: Boolean) {
+        if (value is DecodedValue.DecodedBoolean) {
+            Assert.assertEquals(bool, value.value)
+        } else {
+            throw Exception("Value was not a boolean type")
+        }
+    }
+
+    private fun assertMatches(value: DecodedValue?, long: Long) {
+        if (value is DecodedValue.DecodedLong) {
+            Assert.assertEquals(long, value.value)
+        } else {
+            throw Exception("Value was not a long type")
+        }
+    }
+
+    private fun assertMatches(value: DecodedValue?, float: Float) {
+        if (value is DecodedValue.DecodedFloat) {
+            Assert.assertEquals(float, value.value)
+        } else {
+            throw Exception("Value was not a float type")
+        }
+    }
+
+    private fun assertMatches(value: DecodedValue?, double: Double) {
+        if (value is DecodedValue.DecodedDouble) {
+            Assert.assertEquals(double, value.value, 0.0)
+        } else {
+            throw Exception("Value was not a double type")
+        }
+    }
+
+    private fun assertMatches(value: DecodedValue?, byte: Byte) {
+        if (value is DecodedValue.DecodedByte) {
+            Assert.assertEquals(byte, value.value)
+        } else {
+            throw Exception("Value was not a byte type")
+        }
+    }
+
+    private fun assertMatches(value: DecodedValue?, char: Char) {
+        if (value is DecodedValue.DecodedChar) {
+            Assert.assertEquals(char, value.value)
+        } else {
+            throw Exception("Value was not a char type")
+        }
+    }
+
+    private fun assertMatches(value: DecodedValue?, short: Short) {
+        if (value is DecodedValue.DecodedShort) {
+            Assert.assertEquals(short, value.value)
+        } else {
+            throw Exception("Value was not a short type")
+        }
+    }
+
+    // endregion
+}

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -3,11 +3,9 @@ package com.linkedin.dex
 import com.linkedin.dex.parser.DecodedValue
 import com.linkedin.dex.parser.DexParser
 import com.linkedin.dex.parser.TestMethod
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
-import java.nio.file.Paths
-import java.util.logging.Level
-import java.util.logging.Logger
 
 class DexParserShould {
     companion object {
@@ -17,21 +15,20 @@ class DexParserShould {
     @Test
     fun parseCorrectNumberOfTestMethods() {
         val testMethods = DexParser.findTestNames(APK_PATH)
-        Logger.getGlobal().log(Level.SEVERE, Paths.get("").toAbsolutePath().toString())
 
-        Assert.assertEquals(15, testMethods.size)
+        assertEquals(15, testMethods.size)
     }
 
     @Test
     fun parseMethodWithMultipleMethodAnnotations() {
         val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
 
-        Assert.assertEquals(2, testMethods.size)
+        assertEquals(2, testMethods.size)
 
         val method = testMethods.first()
-        Assert.assertEquals(method.testName, "com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4")
+        assertEquals(method.testName, "com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4")
         // TestValueAnnotation at the class level, Test annotation at the method level, and TestValueAnnotation at the method level
-        Assert.assertEquals(method.annotations.size, 3)
+        assertEquals(method.annotations.size, 3)
     }
 
     @Test
@@ -41,7 +38,7 @@ class DexParserShould {
 
         val classAnnotation = valueAnnotations.first()
         val stringValue = classAnnotation.values["stringValue"]
-        Assert.assertNotNull(stringValue)
+        assertNotNull(stringValue)
         assertMatches(stringValue, "Hello world!")
 
         val methodAnnotation = valueAnnotations[1]
@@ -144,10 +141,10 @@ class DexParserShould {
     private fun getBasicJunit4TestMethod(): TestMethod {
         val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4") }
 
-        Assert.assertEquals(1, testMethods.size)
+        assertEquals(1, testMethods.size)
 
         val method = testMethods.first()
-        Assert.assertEquals(method.testName, "com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4")
+        assertEquals(method.testName, "com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4")
 
         return method
     }
@@ -155,10 +152,10 @@ class DexParserShould {
     private fun getSecondBasicJunit4TestMethod(): TestMethod {
         val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second") }
 
-        Assert.assertEquals(1, testMethods.size)
+        assertEquals(1, testMethods.size)
 
         val method = testMethods.first()
-        Assert.assertEquals(method.testName, "com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second")
+        assertEquals(method.testName, "com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second")
 
         return method
     }
@@ -166,7 +163,7 @@ class DexParserShould {
     // region value type matchers
     private fun assertMatches(value: DecodedValue?, string: String) {
         if (value is DecodedValue.DecodedString) {
-            Assert.assertEquals(string, value.value)
+            assertEquals(string, value.value)
         } else {
             throw Exception("Value was not a string type")
         }
@@ -174,7 +171,7 @@ class DexParserShould {
 
     private fun assertMatches(value: DecodedValue?, number: Int) {
         if (value is DecodedValue.DecodedInt) {
-            Assert.assertEquals(number, value.value)
+            assertEquals(number, value.value)
         } else {
             throw Exception("Value was not an int type")
         }
@@ -182,7 +179,7 @@ class DexParserShould {
 
     private fun assertMatches(value: DecodedValue?, bool: Boolean) {
         if (value is DecodedValue.DecodedBoolean) {
-            Assert.assertEquals(bool, value.value)
+            assertEquals(bool, value.value)
         } else {
             throw Exception("Value was not a boolean type")
         }
@@ -190,7 +187,7 @@ class DexParserShould {
 
     private fun assertMatches(value: DecodedValue?, long: Long) {
         if (value is DecodedValue.DecodedLong) {
-            Assert.assertEquals(long, value.value)
+            assertEquals(long, value.value)
         } else {
             throw Exception("Value was not a long type")
         }
@@ -198,7 +195,7 @@ class DexParserShould {
 
     private fun assertMatches(value: DecodedValue?, float: Float) {
         if (value is DecodedValue.DecodedFloat) {
-            Assert.assertEquals(float, value.value)
+            assertEquals(float, value.value)
         } else {
             throw Exception("Value was not a float type")
         }
@@ -206,7 +203,7 @@ class DexParserShould {
 
     private fun assertMatches(value: DecodedValue?, double: Double) {
         if (value is DecodedValue.DecodedDouble) {
-            Assert.assertEquals(double, value.value, 0.0)
+            assertEquals(double, value.value, 0.0)
         } else {
             throw Exception("Value was not a double type")
         }
@@ -214,7 +211,7 @@ class DexParserShould {
 
     private fun assertMatches(value: DecodedValue?, byte: Byte) {
         if (value is DecodedValue.DecodedByte) {
-            Assert.assertEquals(byte, value.value)
+            assertEquals(byte, value.value)
         } else {
             throw Exception("Value was not a byte type")
         }
@@ -222,7 +219,7 @@ class DexParserShould {
 
     private fun assertMatches(value: DecodedValue?, char: Char) {
         if (value is DecodedValue.DecodedChar) {
-            Assert.assertEquals(char, value.value)
+            assertEquals(char, value.value)
         } else {
             throw Exception("Value was not a char type")
         }
@@ -230,7 +227,7 @@ class DexParserShould {
 
     private fun assertMatches(value: DecodedValue?, short: Short) {
         if (value is DecodedValue.DecodedShort) {
-            Assert.assertEquals(short, value.value)
+            assertEquals(short, value.value)
         } else {
             throw Exception("Value was not a short type")
         }

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
@@ -8,9 +8,11 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
+@TestValueAnnotation("Hello world!")
 public class BasicJUnit4 {
 
     @Test
+    @TestValueAnnotation("On a method")
     public void basicJUnit4() {
         assertTrue(true);
     }

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
@@ -8,12 +8,18 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
-@TestValueAnnotation("Hello world!")
+@TestValueAnnotation(stringValue = "Hello world!")
 public class BasicJUnit4 {
 
     @Test
-    @TestValueAnnotation("On a method")
+    @TestValueAnnotation(stringValue = "On a method", intValue = 12345, boolValue = true, longValue = 56789L)
     public void basicJUnit4() {
+        assertTrue(true);
+    }
+
+    @Test
+    @TestValueAnnotation(floatValue = 0.25f, doubleValue = 0.5, byteValue = 0x0f, charValue = '?', shortValue = 3)
+    public void basicJUnit4Second() {
         assertTrue(true);
     }
 }

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/TestValueAnnotation.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/TestValueAnnotation.java
@@ -26,7 +26,7 @@ public @interface TestValueAnnotation {
 
     float floatValue() default 0f;
 
-    double doubleValue() default 0f;
+    double doubleValue() default 0d;
 
     byte byteValue() default 0;
 

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/TestValueAnnotation.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/TestValueAnnotation.java
@@ -16,5 +16,21 @@ import java.lang.annotation.Target;
 public @interface TestValueAnnotation {
 
     @NonNull
-    String value();
+    String stringValue() default "";
+
+    int intValue() default 0;
+
+    boolean boolValue() default false;
+
+    long longValue() default 0L;
+
+    float floatValue() default 0f;
+
+    double doubleValue() default 0f;
+
+    byte byteValue() default 0;
+
+    char charValue() default 0;
+
+    short shortValue() default 0;
 }

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/TestValueAnnotation.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/TestValueAnnotation.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.parser.test.junit4.java;
+
+import android.support.annotation.NonNull;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ java.lang.annotation.ElementType.METHOD, ElementType.TYPE })
+public @interface TestValueAnnotation {
+
+    @NonNull
+    String value();
+}


### PR DESCRIPTION
This adds support for reading the values included in annotations, as opposed to just the name and presence. It changes the TestMethod
class to contain a new list of TestAnnotation objects, each of which represents a single annotation with its name and all values included.
To do this, we introduce the concept of Encoded and Decoded value classes. The EncodedValue class matches up with the spec, and the DecodedValue
class converts it to a more usable format.

A few of the complex encoded values (fields, methods, etc) still need to be implemented in the DecodedValue class, but I wanted to get this up
since those are relatively rarely used. Implementing these will require the addition of new data classes to represent those types, since they
are not primitives.