### PR TITLE
Fix magic dex version

### DIFF
--- a/parser/src/main/kotlin/com/linkedin/dex/spec/DexMagic.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/DexMagic.kt
@@ -21,14 +21,20 @@ data class DexMagic(
     )
 
     fun validate() {
-        val expectedMagic = DexMagic(
-                dex = listOf(0x64, 0x65, 0x78),
-                newline = 0xA,
-                version = listOf(0x30, 0x33, 0x35),
-                zero = 0x00
-        )
-        if (this != expectedMagic) {
-            throw DexException("Invalid dexMagic:\n" + this + "\n" + expectedMagic)
+        val finalVersionValue = listOf(0x35, 0x37, 0x38)
+
+        finalVersionValue.forEach {
+            val expectedMagic = DexMagic(
+                    dex = listOf(0x64, 0x65, 0x78),
+                    newline = 0xA,
+                    version = listOf(0x30, 0x33, it.toByte()),
+                    zero = 0x00
+            )
+            if (this == expectedMagic) {
+                return
+            }
         }
+        throw DexException("Invalid dexMagic:\n" + this + "\n")
+
     }
 }

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/DexMagic.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/DexMagic.kt
@@ -35,6 +35,5 @@ data class DexMagic(
             }
         }
         throw DexException("Invalid dexMagic:\n" + this + "\n")
-
     }
 }

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/DexMagic.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/DexMagic.kt
@@ -21,13 +21,13 @@ data class DexMagic(
     )
 
     fun validate() {
-        val finalVersionValue = listOf(0x35, 0x37, 0x38)
+        val finalVersionValues = listOf(0x35, 0x37, 0x38)
 
-        finalVersionValue.forEach {
+        finalVersionValues.forEach { version ->
             val expectedMagic = DexMagic(
                     dex = listOf(0x64, 0x65, 0x78),
                     newline = 0xA,
-                    version = listOf(0x30, 0x33, it.toByte()),
+                    version = listOf(0x30, 0x33, version.toByte()),
                     zero = 0x00
             )
             if (this == expectedMagic) {


### PR DESCRIPTION
Fixed the problem with magic version. From Android 7 the version value is 037 and in android 8 the version value is 038. 

These changes produce an exception when the library tries to verify the Dex version. This fix provides a simple solution to pass the validation with the new version values.