### PR TITLE
add main class for jar

### DIFF
--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -25,6 +25,14 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     from javadoc.destinationDir
 }
 
+jar {
+    manifest {
+        attributes (
+            'Main-Class': 'com.linkedin.dex.parser.DexParser'
+        )
+    }
+}
+
 publishing {
     publications {
         lib(MavenPublication) {


### PR DESCRIPTION
Fix missing manifest for running parser.jar from command-line. 
https://github.com/linkedin/dex-test-parser/issues/18