### PR TITLE
Fix reporting for default interface methods and private methods

### DIFF
--- a/parser/ValidTestList.txt
+++ b/parser/ValidTestList.txt
@@ -14,6 +14,8 @@ com.linkedin.parser.test.junit4.java.ConcreteTest#abstractTest
 com.linkedin.parser.test.junit4.java.ConcreteTest#concreteTest
 com.linkedin.parser.test.junit4.java.JUnit4ClassInsideInterface$InnerClass#innerClassTest
 com.linkedin.parser.test.junit4.java.JUnit4TestInsideStaticInnerClass$InnerClass#innerClassTest
+com.linkedin.parser.test.junit4.kotlin.DefaultInterfaceImplementation#testMethodShouldNotBeReported
+com.linkedin.parser.test.junit4.kotlin.DefaultInterfaceImplementation#testToBeOverrideShouldNotBeReportedInInterface
 com.linkedin.parser.test.junit4.kotlin.KotlinJUnit4Basic#testKotlinJUnit4Basic
 com.linkedin.parser.test.junit4.kotlin.KotlinJUnit4TestInsideStaticInnerClass$InnerClass#testKotlinJUnit4TestInsideStaticInnerClass
 com.linkedin.parser.test.junit4.kotlin.KotlinJUnit4WithAnnotations#testKotlinJUnit4WithAnnotations

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DexFileUtils.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DexFileUtils.kt
@@ -5,6 +5,13 @@ import com.linkedin.dex.spec.ClassDefItem
 import com.linkedin.dex.spec.DexFile
 
 fun DexFile.findMethodIdxs(classDefItem: ClassDefItem): List<Int> {
+    // We need to catch the classes have an offset of 0, and so have no data in this apk to read
+    // From the docs: "0 if there is no class data for this class. (This may be the case, for example,
+    // if this class is a marker interface.)"
+    if (classDefItem.classDataOff == 0) {
+        return emptyList()
+    }
+
     val methodIds = mutableListOf<Int>()
     val testClassData = ClassDataItem.create(byteBuffer, classDefItem.classDataOff)
     var previousMethodIdxOff = 0

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DexFileUtils.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DexFileUtils.kt
@@ -1,0 +1,21 @@
+package com.linkedin.dex.parser
+
+import com.linkedin.dex.spec.ClassDataItem
+import com.linkedin.dex.spec.ClassDefItem
+import com.linkedin.dex.spec.DexFile
+
+fun DexFile.findMethodIdxs(classDefItem: ClassDefItem): List<Int> {
+    val methodIds = mutableListOf<Int>()
+    val testClassData = ClassDataItem.create(byteBuffer, classDefItem.classDataOff)
+    var previousMethodIdxOff = 0
+    testClassData.virtualMethods.forEachIndexed { index, encodedMethod ->
+        var methodIdxOff = encodedMethod.methodIdxDiff
+        if (index != 0) {
+            methodIdxOff += previousMethodIdxOff
+        }
+        previousMethodIdxOff = methodIdxOff
+
+        methodIds.add(methodIdxOff)
+    }
+    return methodIds
+}

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit3Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit3Extensions.kt
@@ -68,20 +68,8 @@ private fun DexFile.findJUnit3Tests(descriptors: MutableSet<String>): List<TestM
             .filter { it.testName.contains("#test") }
 }
 
-private fun DexFile.findMethodIds(classDefItem: ClassDefItem): MutableList<MethodIdItem> {
-    val methodIds = mutableListOf<MethodIdItem>()
-    val testClassData = ClassDataItem.create(byteBuffer, classDefItem.classDataOff)
-    var previousMethodIdxOff = 0
-    testClassData.virtualMethods.forEachIndexed { index, encodedMethod ->
-        var methodIdxOff = encodedMethod.methodIdxDiff
-        if (index != 0) {
-            methodIdxOff += previousMethodIdxOff
-        }
-        previousMethodIdxOff = methodIdxOff
-
-        methodIds.add(this.methodIds[methodIdxOff])
-    }
-    return methodIds
+fun DexFile.findMethodIds(classDefItem: ClassDefItem): MutableList<MethodIdItem> {
+    return findMethodIdxs(classDefItem).map { this.methodIds[it] }.toMutableList()
 }
 
 // From the docs:

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -16,7 +16,7 @@ class DexParserShould {
     fun parseCorrectNumberOfTestMethods() {
         val testMethods = DexParser.findTestNames(APK_PATH)
 
-        assertEquals(19, testMethods.size)
+        assertEquals(21, testMethods.size)
     }
 
     @Test

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
@@ -22,4 +22,9 @@ public class BasicJUnit4 extends ConcreteTest {
     public void basicJUnit4Second() {
         assertTrue(true);
     }
+
+    @Test
+    private void privateTestShouldNotBeReported() {
+        assertTrue(true);
+    }
 }

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/kotlin/DefaultInterfaceImplementation.kt
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/kotlin/DefaultInterfaceImplementation.kt
@@ -1,0 +1,10 @@
+package com.linkedin.parser.test.junit4.kotlin
+
+import org.junit.Test
+
+class DefaultInterfaceImplementation : InterfaceWithDefaultMethods {
+    @Test
+    override fun testToBeOverrideShouldNotBeReportedInInterface() {
+        super.testToBeOverrideShouldNotBeReportedInInterface()
+    }
+}

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/kotlin/InterfaceWithDefaultMethod.kt
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/kotlin/InterfaceWithDefaultMethod.kt
@@ -1,0 +1,9 @@
+package com.linkedin.parser.test.junit4.kotlin
+
+import org.junit.Test
+
+interface InterfaceWithDefaultMethod {
+    @Test
+    fun testMethodShouldNotBeReported() {
+    }
+}

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/kotlin/InterfaceWithDefaultMethods.kt
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/kotlin/InterfaceWithDefaultMethods.kt
@@ -2,8 +2,12 @@ package com.linkedin.parser.test.junit4.kotlin
 
 import org.junit.Test
 
-interface InterfaceWithDefaultMethod {
+interface InterfaceWithDefaultMethods {
     @Test
     fun testMethodShouldNotBeReported() {
+    }
+
+    @Test
+    fun testToBeOverrideShouldNotBeReportedInInterface() {
     }
 }


### PR DESCRIPTION
Previously, we were reporting both default interface methods and private methods that were annotated with @Test
as valid, when in reality neither is true. To fix this, we can take advantage of the differentiation the dex file
format makes in the class_data_item struct, which contains 2 sets of methods: direct_methods and virtual_methods.
For tests, all we really care about are the virtual methods, which are "none of static, private, or constructor"
methods on the class. So this updates our logic for both junit3 and junit4 to only look in the virtual_methods set
for tests.