### PR TITLE
Bump to AGP 3.2.1, add Java8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-26.0.0
+    - build-tools-26.0.2
     - android-26
     - extra-android-support
     - extra-android-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,22 @@
 import com.linkedin.gradle.DistributeTask
 
 buildscript {
-    ext.kotlinVersion = '1.1.2'
+    ext.kotlinVersion = '1.2.71'
 
     repositories {
+        google()
         jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4'
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.0'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
-        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.9.9'
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.8.1'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.1'
+        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.9.17'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
+
 }
 
 apply plugin: 'com.jfrog.artifactory'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,6 +2,14 @@ plugins {
     id 'groovy'
 }
 
+// Our dependencies are pulling in older version of guava, but agp3 requires guava 21. So, we force it here
+configurations.runtimeClasspath {
+    println it
+    resolutionStrategy {
+        force 'com.google.guava:guava:21.0'
+    }
+}
+
 repositories {
     mavenLocal()
     jcenter()
@@ -11,9 +19,9 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    compile 'org.ajoberstar:gradle-git:1.2.0'
+    compile 'org.ajoberstar:gradle-git:1.7.2'
     compile group: 'org.apache.httpcomponents', name: 'fluent-hc', version: '4.5.2'
-    compile('org.jfrog.buildinfo:build-info-extractor-gradle:4.4.0') {
+    compile('org.jfrog.buildinfo:build-info-extractor-gradle:4.8.1') {
         exclude module: 'groovy-all'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/parser/ValidTestList.txt
+++ b/parser/ValidTestList.txt
@@ -14,6 +14,8 @@ com.linkedin.parser.test.junit4.java.ConcreteTest#abstractTest
 com.linkedin.parser.test.junit4.java.ConcreteTest#concreteTest
 com.linkedin.parser.test.junit4.java.JUnit4ClassInsideInterface$InnerClass#innerClassTest
 com.linkedin.parser.test.junit4.java.JUnit4TestInsideStaticInnerClass$InnerClass#innerClassTest
+com.linkedin.parser.test.junit4.java.JavaDefaultInterfaceImpl#notOverriddenTest
+com.linkedin.parser.test.junit4.java.JavaDefaultInterfaceImpl#overriddenTest
 com.linkedin.parser.test.junit4.kotlin.DefaultInterfaceImplementation#testMethodShouldNotBeReported
 com.linkedin.parser.test.junit4.kotlin.DefaultInterfaceImplementation#testToBeOverrideShouldNotBeReportedInInterface
 com.linkedin.parser.test.junit4.kotlin.KotlinJUnit4Basic#testKotlinJUnit4Basic

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -83,7 +83,7 @@ build.dependsOn shadowJar
 task testParsing(dependsOn: ':test-app:assembleDebugAndroidTest', type: JavaExec) {
     classpath sourceSets.main.runtimeClasspath
     main = 'com.linkedin.dex.parser.DexParser'
-    args "${rootProject.project('test-app').buildDir}/outputs/apk/test-app-debug-androidTest.apk", "$buildDir"
+    args "${rootProject.project('test-app').buildDir}/outputs/apk/androidTest/debug/test-app-debug-androidTest.apk", "$buildDir"
 
     doLast {
         def validTests = file('ValidTestList.txt').readLines()

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -9,14 +9,14 @@ import org.junit.Test
 
 class DexParserShould {
     companion object {
-        val APK_PATH = "test-app/build/outputs/apk/test-app-debug-androidTest.apk"
+        val APK_PATH = "test-app/build/outputs/apk/androidTest/debug/test-app-debug-androidTest.apk"
     }
 
     @Test
     fun parseCorrectNumberOfTestMethods() {
         val testMethods = DexParser.findTestNames(APK_PATH)
 
-        assertEquals(21, testMethods.size)
+        assertEquals(23, testMethods.size)
     }
 
     @Test

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.0"
+    buildToolsVersion "26.0.2"
     defaultConfig {
         applicationId "com.linkedin.parser.test"
         minSdkVersion 15
@@ -15,14 +15,16 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
 }
 
 repositories {
+    google()
     jcenter()
-    maven {
-        url "https://maven.google.com"
-    }
 }
 
 dependencies {

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/JavaDefaultInterfaceImpl.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/JavaDefaultInterfaceImpl.java
@@ -1,0 +1,10 @@
+package com.linkedin.parser.test.junit4.java;
+
+import org.junit.Test;
+
+public class JavaDefaultInterfaceImpl implements  JavaInterfacewithDefaultMethods{
+    @Override
+    @Test
+    public void overriddenTest() {
+    }
+}

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/JavaInterfacewithDefaultMethods.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/JavaInterfacewithDefaultMethods.java
@@ -1,0 +1,14 @@
+package com.linkedin.parser.test.junit4.java;
+
+import org.junit.Test;
+
+public interface JavaInterfacewithDefaultMethods {
+
+    @Test
+    default void overriddenTest() {
+    }
+
+    @Test
+    default void notOverriddenTest() {
+    }
+}


### PR DESCRIPTION
We needed to bump our AGP version past 3.0 so that we could use Java8 in the sample app for tests.
There was an issue where one of our buildsrc dependencies was forcing a lower version of guava than
what AGP expected, so to fix it we force it up to version 21 to make everyon happy.