### PR TITLE
Fix #21 bufferoverflow when parsing test annotations

### DIFF
--- a/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedValue.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedValue.kt
@@ -44,7 +44,7 @@ sealed class EncodedValue {
         val VALUE_BOOLEAN: Byte = 0x1f
 
         fun create(byteBuffer: ByteBuffer): EncodedValue {
-            val argAndType = byteBuffer.get().toInt()
+            val argAndType = byteBuffer.get().toInt().toUnsigned8BitInt()
 
             // first three bits are the optional valueArg
             val valueArg = (argAndType ushr 5).toByte()
@@ -126,3 +126,5 @@ sealed class EncodedValue {
         }
     }
 }
+
+private fun Int.toUnsigned8BitInt(): Int = (this and 0xFF)

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedValue.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/EncodedValue.kt
@@ -44,7 +44,7 @@ sealed class EncodedValue {
         val VALUE_BOOLEAN: Byte = 0x1f
 
         fun create(byteBuffer: ByteBuffer): EncodedValue {
-            val argAndType = byteBuffer.get().toInt().toUnsigned8BitInt()
+            val argAndType = byteBuffer.get().toUnsigned8BitInt()
 
             // first three bits are the optional valueArg
             val valueArg = (argAndType ushr 5).toByte()
@@ -127,4 +127,4 @@ sealed class EncodedValue {
     }
 }
 
-private fun Int.toUnsigned8BitInt(): Int = (this and 0xFF)
+private fun Byte.toUnsigned8BitInt(): Int = (this.toInt() and 0xFF)

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -83,7 +83,7 @@ class DexParserShould {
 
         val methodAnnotation = valueAnnotations[1]
         val value = methodAnnotation.values["floatValue"]
-        assertMatches(value, .25f)
+        assertMatches(value, 0.25f)
     }
 
     @Test
@@ -93,7 +93,7 @@ class DexParserShould {
 
         val methodAnnotation = valueAnnotations[1]
         val value = methodAnnotation.values["doubleValue"]
-        assertMatches(value, .5)
+        assertMatches(value, 0.5)
     }
 
     @Test
@@ -104,6 +104,18 @@ class DexParserShould {
         val methodAnnotation = valueAnnotations[1]
         val value = methodAnnotation.values["byteValue"]
         assertMatches(value, 0x0f.toByte())
+    }
+
+    @Test
+    fun parseFloatMaxValuesInDoubleFields() {
+        val method = getSecondBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("FloatRange") }
+
+        val methodAnnotation = valueAnnotations[0]
+        val from = methodAnnotation.values["from"]
+        assertMatches(from, 0f.toDouble())
+        val to = methodAnnotation.values["to"]
+        assertMatches(to, Float.MAX_VALUE.toDouble())
     }
 
     @Test

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
@@ -19,6 +19,7 @@ public class BasicJUnit4 extends ConcreteTest {
 
     @Test
     @TestValueAnnotation(floatValue = 0.25f, doubleValue = 0.5, byteValue = 0x0f, charValue = '?', shortValue = 3)
+    @FloatRange(from = 0f, to = Float.MAX_VALUE)
     public void basicJUnit4Second() {
         assertTrue(true);
     }

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/FloatRange.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/FloatRange.java
@@ -1,0 +1,25 @@
+package com.linkedin.parser.test.junit4.java;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+@Retention(CLASS)
+@Target({ METHOD, PARAMETER, FIELD, LOCAL_VARIABLE})
+public @interface FloatRange {
+    /** Smallest value. Whether it is inclusive or not is determined
+     * by {@link #fromInclusive} */
+    double from() default Double.NEGATIVE_INFINITY;
+    /** Largest value. Whether it is inclusive or not is determined
+     * by {@link #toInclusive} */
+    double to() default Double.POSITIVE_INFINITY;
+    /** Whether the from value is included in the range */
+    boolean fromInclusive() default true;
+    /** Whether the to value is included in the range */
+    boolean toInclusive() default true;
+}


### PR DESCRIPTION
We should never have been seeing negative values for the size of annotations, as the byte that they
are stored in is unsigned. However, in the process of converting the byte to an int (kotlin has no
bitwise operators available to byte types), we were padding with a bunch of 1s causing it to be read
as a signed number. Forcing it down to an unsigned 8 bit value resolves this issue and lets us read the
values out correctly.