### PR TITLE
Merge child class annotations with parent class annotations

### DIFF
--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
@@ -91,6 +91,7 @@ private fun createTestMethodsFromSuperMethods(dexFile: DexFile, classDefItem: Cl
 
     val tests = superTests.map { method ->
         val onlyParentAnnotations = method.annotations.filterNot { childClassAnnotationNames.contains(it.name) }
+                .filter { it.inherited }
         TestMethod(className + (method.testName.substring(method.testName.indexOf('#') + 1)), onlyParentAnnotations + childClassAnnotations)
     }
     return tests.toSet()

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
@@ -38,7 +38,7 @@ fun findAllJUnit4Tests(dexFiles: List<DexFile>): List<TestMethod> {
                 }.contains(testAnnotationName)
             }
 
-            val superTests = createTestMethodsFromSuperMethods(dexFile.formatClassName(classDef), getSuperTestMethods(classDef, classTestMethods, dexFile))
+            val superTests = createTestMethodsFromSuperMethods(dexFile, classDef, dexFile.formatClassName(classDef), getSuperTestMethods(classDef, classTestMethods, dexFile))
             classTestMethods[dexFile.getClassName(classDef)] = ClassParsingResult(dexFile.getSuperclassName(classDef), baseTests union superTests, !(isAbstract(classDef) || isInterface(classDef)))
         }
     }
@@ -84,10 +84,16 @@ private fun DexFile.getSuperclassName(classDefItem: ClassDefItem): String {
 /**
  * Creates new TestMethod objects with the class name changed from the super class to the subclass
  */
-private fun createTestMethodsFromSuperMethods(className: String, superTests: Set<TestMethod>): Set<TestMethod> {
-    return superTests.map {
-        TestMethod(className + (it.testName.substring(it.testName.indexOf('#') + 1)), it.annotations)
-    }.toSet()
+private fun createTestMethodsFromSuperMethods(dexFile: DexFile, classDefItem: ClassDefItem, className: String, superTests: Set<TestMethod>): Set<TestMethod> {
+    val directory = dexFile.getAnnotationsDirectory(classDefItem)
+    val childClassAnnotations = dexFile.getClassAnnotationValues(directory)
+    val childClassAnnotationNames = childClassAnnotations.map { it.name }
+
+    val tests = superTests.map { method ->
+        val onlyParentAnnotations = method.annotations.filterNot { childClassAnnotationNames.contains(it.name) }
+        TestMethod(className + (method.testName.substring(method.testName.indexOf('#') + 1)), onlyParentAnnotations + childClassAnnotations)
+    }
+    return tests.toSet()
 }
 
 private fun isInterface(classDefItem: ClassDefItem): Boolean {

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/TestAnnotation.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/TestAnnotation.kt
@@ -4,4 +4,4 @@ package com.linkedin.dex.parser
  * A class to represent an annotation on method. Includes both the name of the annotation itself,
  * and all of the values within it as a key-value map of name string to value
  */
-data class TestAnnotation(val name: String, val values: Map<String, DecodedValue>)
+data class TestAnnotation(val name: String, val values: Map<String, DecodedValue>, val inherited: Boolean)

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -4,7 +4,9 @@ import com.linkedin.dex.parser.DecodedValue
 import com.linkedin.dex.parser.DexParser
 import com.linkedin.dex.parser.TestMethod
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DexParserShould {
@@ -37,7 +39,17 @@ class DexParserShould {
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#abstractTest", method.testName)
+        assertEquals(method.annotations[0].values["stringValue"], DecodedValue.DecodedString("Hello world!"))
+    }
+
+    @Test
+    fun parseInheritedAnnotation() {
+        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
+
+        val method = testMethods[0]
+        assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
         assertEquals(method.annotations[1].values["stringValue"], DecodedValue.DecodedString("Hello world!"))
+        assertFalse(method.annotations.any { it.name.contains("NonInheritedAnnotation") })
     }
 
     @Test

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -23,12 +23,21 @@ class DexParserShould {
     fun parseMethodWithMultipleMethodAnnotations() {
         val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
 
-        assertEquals(2, testMethods.size)
+        assertEquals(4, testMethods.size)
 
-        val method = testMethods.first()
+        val method = testMethods[1]
         assertEquals(method.testName, "com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4")
         // TestValueAnnotation at the class level, Test annotation at the method level, and TestValueAnnotation at the method level
         assertEquals(method.annotations.size, 3)
+    }
+
+    @Test
+    fun parseMethodWithChildclassAnnotation() {
+        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
+
+        val method = testMethods[0]
+        assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#abstractTest", method.testName)
+        assertEquals(method.annotations[1].values["stringValue"], DecodedValue.DecodedString("Hello world!"))
     }
 
     @Test

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -39,17 +39,34 @@ class DexParserShould {
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#abstractTest", method.testName)
-        assertEquals(method.annotations[0].values["stringValue"], DecodedValue.DecodedString("Hello world!"))
+        assertEquals(method.annotations[1].values["stringValue"], DecodedValue.DecodedString("Hello world!"))
     }
 
     @Test
-    fun parseInheritedAnnotation() {
+    fun parseInheritedMethodAnnotation() {
         val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
-        assertEquals(method.annotations[1].values["stringValue"], DecodedValue.DecodedString("Hello world!"))
+        assertEquals(method.annotations[2].values["stringValue"], DecodedValue.DecodedString("Hello world!"))
+    }
+
+    @Test
+    fun parsNonInheritedMethodAnnotation() {
+        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
+
+        val method = testMethods[0]
+        assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
         assertFalse(method.annotations.any { it.name.contains("NonInheritedAnnotation") })
+    }
+
+    @Test
+    fun parseInheritedClassAnnotation() {
+        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
+
+        val method = testMethods[0]
+        assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
+        assertTrue(method.annotations.any { it.name == "com.linkedin.parser.test.junit4.java.InheritedClassAnnotation" })
     }
 
     @Test

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/ConcreteTest.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/ConcreteTest.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 import static org.junit.Assert.assertTrue;
 
 public class ConcreteTest extends AbstractTest {
+
+    @NonInheritedAnnotation
+    @InheritedAnnotation
     @Test
     public void concreteTest() {
         assertTrue(true);

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/ConcreteTest.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/ConcreteTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
+@InheritedClassAnnotation
 public class ConcreteTest extends AbstractTest {
 
     @NonInheritedAnnotation

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/InheritedAnnotation.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/InheritedAnnotation.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.parser.test.junit4.java;
+
+import java.lang.annotation.*;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+public @interface InheritedAnnotation {
+}

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/InheritedClassAnnotation.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/InheritedClassAnnotation.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.parser.test.junit4.java;
+
+import java.lang.annotation.*;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+public @interface InheritedClassAnnotation {
+}

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/NonInheritedAnnotation.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/NonInheritedAnnotation.java
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.parser.test.junit4.java;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+public @interface NonInheritedAnnotation {
+}


### PR DESCRIPTION
The child annotations have precedence over the parent ones now.

This might break some things, but this use case is quite common for inheritance in the test classes, e.g:

- BaseClassTest
- TestA extends BaseClassTest and has some conditional thing in the test, e.g. val or TestRule that is used in the tests. We annotation this test class as ```@FeatureA```
- TestB extends BaseClassTest and has another value for the conditional value. We annotation this test class as ```@FeatureB```

Currently those annotations are not present in the parsing result. This PR merges the annotations present in the hierarchy of test classes allowing to filter tests based on child classes annotations.