### PR TITLE
Add isClassAnnotation to TestAnnotation

### DIFF
--- a/parser/src/main/kotlin/com/linkedin/dex/parser/AnnotationUtils.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/AnnotationUtils.kt
@@ -43,7 +43,7 @@ fun DexFile.getClassAnnotationValues(directory: AnnotationsDirectoryItem?): List
 
     val classAnnotationSetItem = AnnotationSetItem.create(byteBuffer, directory.classAnnotationsOff)
 
-    return classAnnotationSetItem.entries.map { AnnotationItem.create(byteBuffer, it.annotationOff) }.map { getTestAnnotation(it) }
+    return classAnnotationSetItem.entries.map { AnnotationItem.create(byteBuffer, it.annotationOff) }.map { getTestAnnotation(it, true) }
 }
 
 /**
@@ -61,7 +61,7 @@ fun DexFile.getMethodAnnotationValues(methodId: MethodIdItem, annotationsDirecto
     }.flatten()
 }
 
-fun DexFile.getTestAnnotation(annotationItem: AnnotationItem): TestAnnotation {
+fun DexFile.getTestAnnotation(annotationItem: AnnotationItem, isClassAnnotation: Boolean = false): TestAnnotation {
     val name = formatDescriptor(ParseUtils.parseDescriptor(byteBuffer,
             typeIds[annotationItem.encodedAnnotation.typeIdx], stringIds))
     val encodedAnnotationValues = annotationItem.encodedAnnotation.elements
@@ -73,5 +73,5 @@ fun DexFile.getTestAnnotation(annotationItem: AnnotationItem): TestAnnotation {
         values.put(valueName, value)
     }
 
-    return TestAnnotation(name, values)
+    return TestAnnotation(name, values, isClassAnnotation)
 }

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/TestAnnotation.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/TestAnnotation.kt
@@ -4,4 +4,4 @@ package com.linkedin.dex.parser
  * A class to represent an annotation on method. Includes both the name of the annotation itself,
  * and all of the values within it as a key-value map of name string to value
  */
-data class TestAnnotation(val name: String, val values: Map<String, DecodedValue>)
+data class TestAnnotation(val name: String, val values: Map<String, DecodedValue>, val isClassAnnotation: Boolean)

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -4,7 +4,9 @@ import com.linkedin.dex.parser.DecodedValue
 import com.linkedin.dex.parser.DexParser
 import com.linkedin.dex.parser.TestMethod
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DexParserShould {
@@ -40,10 +42,12 @@ class DexParserShould {
         val stringValue = classAnnotation.values["stringValue"]
         assertNotNull(stringValue)
         assertMatches(stringValue, "Hello world!")
+        assertTrue(classAnnotation.isClassAnnotation)
 
         val methodAnnotation = valueAnnotations[1]
         val methodStringValue = methodAnnotation.values["stringValue"]
         assertMatches(methodStringValue, "On a method")
+        assertFalse(methodAnnotation.isClassAnnotation)
     }
 
     @Test


### PR DESCRIPTION
Currently, TestAnnotations are returned in a flat list, with no way to tell the difference between class and method annotations. The workaround is to parse the annotation name and try to infer the type (e.g. RunWith), but that approach is fragile. 

Having an `isClassAnnotation` field helps callers disambiguate the annotation types easily.