### PR TITLE
Add support for encoded array values

### DIFF
--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DecodedValue.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DecodedValue.kt
@@ -25,10 +25,9 @@ sealed class DecodedValue {
     object DecodedNull : DecodedValue()
     data class DecodedBoolean(val value: Boolean) : DecodedValue()
     data class DecodedEnum(val value: String) : DecodedValue()
-    // TODO: DecodedType
+    data class DecodedArrayValue(val values: Array<DecodedValue>): DecodedValue()
     // TODO: DecodedField
     // TODO: DecodedMethod
-    // TODO: DecodedArrayValue
     // TODO: DecodedAnnotationValue
 
     companion object {
@@ -67,6 +66,8 @@ sealed class DecodedValue {
                     val position = dexFile.stringIds[index].stringDataOff
                     return DecodedEnum(readStringInPosition(dexFile, position))
                 }
+                is EncodedValue.EncodedArrayValue -> return DecodedArrayValue(encodedValue.value.values.map { create(dexFile, it) }.toTypedArray())
+
                 else -> return DecodedNull
             }
         }

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -3,7 +3,11 @@ package com.linkedin.dex
 import com.linkedin.dex.parser.DecodedValue
 import com.linkedin.dex.parser.DexParser
 import com.linkedin.dex.parser.TestMethod
-import org.junit.Assert.*
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DexParserShould {

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -3,10 +3,7 @@ package com.linkedin.dex
 import com.linkedin.dex.parser.DecodedValue
 import com.linkedin.dex.parser.DexParser
 import com.linkedin.dex.parser.TestMethod
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Test
 
 class DexParserShould {
@@ -177,6 +174,20 @@ class DexParserShould {
     }
 
     @Test
+    fun parseClassArrayAnnotationnValues() {
+        val method = getSecondBasicJunit4TestMethod()
+        val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
+
+        val methodAnnotation = valueAnnotations[1]
+        val value = methodAnnotation.values["arrayTypeValue"]
+
+        // We have to use a string as opposed to a class reference in this assertion, since the way
+        // that its actually stored on disk is their special class format and not what class.name
+        // will give
+        assertMatches(value, arrayOf("Ljava/util/function/Function;", "Ljava/lang/Integer;"))
+    }
+
+    @Test
     fun parseMultipleValuesInASingleAnnotation() {
         val method = getBasicJunit4TestMethod()
         val valueAnnotations = method.annotations.filter { it.name.contains("TestValueAnnotation") }
@@ -304,6 +315,16 @@ class DexParserShould {
             throw Exception("Value was not a short type")
         }
     }
+
+    private fun assertMatches(value: DecodedValue?, values: Array<String>) {
+        if (value is DecodedValue.DecodedArrayValue) {
+            val stringValues = value.values.map { (it as? DecodedValue.DecodedType)?.value }.toTypedArray()
+            assertArrayEquals(stringValues, values)
+        } else {
+            throw Exception("Value was not an array value")
+        }
+    }
+
 
     // endregion
 }

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
@@ -6,6 +6,8 @@ package com.linkedin.parser.test.junit4.java;
 
 import org.junit.Test;
 
+import java.util.function.Function;
+
 import static org.junit.Assert.assertTrue;
 
 @TestValueAnnotation(stringValue = "Hello world!")
@@ -18,7 +20,7 @@ public class BasicJUnit4 extends ConcreteTest {
     }
 
     @Test
-    @TestValueAnnotation(floatValue = 0.25f, doubleValue = 0.5, byteValue = 0x0f, charValue = '?', shortValue = 3, enumValue = TestEnum.FAIL, typeValue = Test.class)
+    @TestValueAnnotation(floatValue = 0.25f, doubleValue = 0.5, byteValue = 0x0f, charValue = '?', shortValue = 3, enumValue = TestEnum.FAIL, typeValue = Test.class, arrayTypeValue = { Function.class, Integer.class})
     @FloatRange(from = 0f, to = Float.MAX_VALUE)
     public void basicJUnit4Second() {
         assertTrue(true);

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/TestValueAnnotation.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/TestValueAnnotation.java
@@ -37,4 +37,6 @@ public @interface TestValueAnnotation {
     TestEnum enumValue() default TestEnum.SUCCESS;
 
     Class typeValue() default Object.class;
+
+    Class[] arrayTypeValue() default {};
 }


### PR DESCRIPTION
Encoded arrays are fairly simple - a size value followed by a sequence of elements. We were already parsing these correctly when reading the values from the dex file, we just weren't taking the final step of mapping them into individual DecodedValues. Added implementation and a test.