### PR TITLE
add ability to pass custom test annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import com.linkedin.gradle.DistributeTask
 
 buildscript {
-    ext.kotlinVersion = '1.1.2'
+    ext.kotlinVersion = '1.2.0'
 
     repositories {
         jcenter()

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -73,6 +73,7 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    compile "com.xenomachina:kotlin-argparser:2.0.7"
 
     testCompile 'junit:junit:4.12'
 }
@@ -83,7 +84,7 @@ build.dependsOn shadowJar
 task testParsing(dependsOn: ':test-app:assembleDebugAndroidTest', type: JavaExec) {
     classpath sourceSets.main.runtimeClasspath
     main = 'com.linkedin.dex.parser.DexParser'
-    args "${rootProject.project('test-app').buildDir}/outputs/apk/test-app-debug-androidTest.apk", "$buildDir"
+    args "--apk-path", "${rootProject.project('test-app').buildDir}/outputs/apk/test-app-debug-androidTest.apk", "--output-dir", "$buildDir"
 
     doLast {
         def validTests = file('ValidTestList.txt').readLines()

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -84,7 +84,7 @@ build.dependsOn shadowJar
 task testParsing(dependsOn: ':test-app:assembleDebugAndroidTest', type: JavaExec) {
     classpath sourceSets.main.runtimeClasspath
     main = 'com.linkedin.dex.parser.DexParser'
-    args "--apk-path", "${rootProject.project('test-app').buildDir}/outputs/apk/test-app-debug-androidTest.apk", "--output-dir", "$buildDir"
+    args "${rootProject.project('test-app').buildDir}/outputs/apk/test-app-debug-androidTest.apk", "$buildDir"
 
     doLast {
         def validTests = file('ValidTestList.txt').readLines()

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
@@ -5,6 +5,8 @@
 package com.linkedin.dex.parser
 
 import com.linkedin.dex.spec.DexFile
+import com.xenomachina.argparser.ArgParser
+import com.xenomachina.argparser.default
 import java.io.File
 import java.io.FileInputStream
 import java.nio.ByteBuffer
@@ -19,7 +21,22 @@ import java.util.zip.ZipInputStream
  * NOTE: everything in the spec package is derived from the dex file format spec:
  * https://source.android.com/devices/tech/dalvik/dex-format.html
  */
-class DexParser private constructor() {
+class DexParserArgs(parser: ArgParser) {
+    val apkPath by parser.storing(
+        "-a", "--apk-path",
+        help = "path to apk file")
+
+    val outputDir by parser.storing(
+        "-o",
+        "--output-dir",
+        help = "path to output dir where AllTests.txt file will be saved, if not set output will go to stdout"
+    ).default("")
+
+    val customAnnotations by parser.adding(
+        "-A", help = "add custom annotation used by tests") { toString() }
+}
+
+ class DexParser private constructor() {
     companion object {
 
         /**
@@ -27,29 +44,22 @@ class DexParser private constructor() {
          */
         @JvmStatic
         fun main(vararg args: String) {
-            if ((args.size < 2) or (args.size > 3)) {
-                println("Usage: apkPath outputPath [custom_annotation,]")
-                System.exit(1)
+            val parsedArgs = ArgParser(args).parseInto(::DexParserArgs)
+            parsedArgs.run {
+                val allItems = Companion.findTestNames(apkPath, customAnnotations)
+                if (outputDir.isEmpty()) {
+                    println(allItems.joinToString(separator = "\n"))
+                } else {
+                    Files.write(File(outputDir + "/AllTests.txt").toPath(), allItems)
+                }
             }
-            val apkPath = args[0]
-            val outputPath = args[1]
-            val customAnnotations: String
-            if (args.size == 3) {
-                customAnnotations = args[2]
-            } else {
-                customAnnotations = ""
-            }
-
-            val allItems = Companion.findTestNames(apkPath, customAnnotations)
-
-            Files.write(File(outputPath + "/AllTests.txt").toPath(), allItems)
         }
 
         /**
          * Parse the apk found at [apkPath] and return the list of test names found in the apk
          */
         @JvmStatic
-        fun findTestNames(apkPath: String, customAnnotations: String): List<String> {
+        fun findTestNames(apkPath: String, customAnnotations: List<String>): List<String> {
             return findTestMethods(apkPath, customAnnotations).map { it.testName }
         }
 
@@ -60,7 +70,7 @@ class DexParser private constructor() {
          * explicitly applied to the test method.
          */
         @JvmStatic
-        fun findTestMethods(apkPath: String, customAnnotations: String): List<TestMethod> {
+        fun findTestMethods(apkPath: String, customAnnotations: List<String>): List<TestMethod> {
             val dexFiles = readDexFiles(apkPath)
 
             val junit3Items = findJUnit3Tests(dexFiles).sorted()

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
@@ -22,13 +22,11 @@ import java.util.zip.ZipInputStream
  * https://source.android.com/devices/tech/dalvik/dex-format.html
  */
 class DexParserArgs(parser: ArgParser) {
-    val apkPath by parser.storing(
-        "-a", "--apk-path",
-        help = "path to apk file")
+    val apkPath by parser.positional(
+        help = "path to apk file"
+    )
 
-    val outputDir by parser.storing(
-        "-o",
-        "--output-dir",
+    val outputDir by parser.positional(
         help = "path to output dir where AllTests.txt file will be saved, if not set output will go to stdout"
     ).default("")
 

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
@@ -27,14 +27,20 @@ class DexParser private constructor() {
          */
         @JvmStatic
         fun main(vararg args: String) {
-            if (args.size != 2) {
-                println("Usage: apkPath outputPath")
+            if ((args.size < 2) or (args.size > 3)) {
+                println("Usage: apkPath outputPath [custom_annotation,]")
                 System.exit(1)
             }
             val apkPath = args[0]
             val outputPath = args[1]
+            val customAnnotations: String
+            if (args.size == 3) {
+                customAnnotations = args[2]
+            } else {
+                customAnnotations = ""
+            }
 
-            val allItems = Companion.findTestNames(apkPath)
+            val allItems = Companion.findTestNames(apkPath, customAnnotations)
 
             Files.write(File(outputPath + "/AllTests.txt").toPath(), allItems)
         }
@@ -43,8 +49,8 @@ class DexParser private constructor() {
          * Parse the apk found at [apkPath] and return the list of test names found in the apk
          */
         @JvmStatic
-        fun findTestNames(apkPath: String): List<String> {
-            return findTestMethods(apkPath).map { it.testName }
+        fun findTestNames(apkPath: String, customAnnotations: String): List<String> {
+            return findTestMethods(apkPath, customAnnotations).map { it.testName }
         }
 
         /**
@@ -54,11 +60,11 @@ class DexParser private constructor() {
          * explicitly applied to the test method.
          */
         @JvmStatic
-        fun findTestMethods(apkPath: String): List<TestMethod> {
+        fun findTestMethods(apkPath: String, customAnnotations: String): List<TestMethod> {
             val dexFiles = readDexFiles(apkPath)
 
             val junit3Items = findJUnit3Tests(dexFiles).sorted()
-            val junit4Items = findAllJUnit4Tests(dexFiles).sorted()
+            val junit4Items = findAllJUnit4Tests(dexFiles, customAnnotations).sorted()
 
             return (junit3Items + junit4Items).sorted()
         }

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
@@ -15,7 +15,7 @@ import com.linkedin.dex.spec.MethodIdItem
  * Find all methods that are annotated with JUnit4's @Test annotation, including any test methods that
  * may be inherited from superclasses or interfaces.
  */
-fun findAllJUnit4Tests(dexFiles: List<DexFile>): List<TestMethod> {
+fun findAllJUnit4Tests(dexFiles: List<DexFile>, customAnnotations: String): List<TestMethod> {
 
     // Map to hold all the class information we've found as we go
     // From the docs:
@@ -23,7 +23,7 @@ fun findAllJUnit4Tests(dexFiles: List<DexFile>): List<TestMethod> {
     // implemented interfaces appear in the list earlier than the referring class
     // BUT it's not true for multiple dex files: superclass can be located in a different dex file
     // since the order is not guaranteed in this case we need to traverse all superclasses for each class
-    val classTestMethods: Map<String, ClassParsingResult> = dexFiles.parseClasses()
+    val classTestMethods: Map<String, ClassParsingResult> = dexFiles.parseClasses(customAnnotations)
 
     // Map for the second iteration to cache all found test methods including methods from superclass
     val classAllTestMethods: MutableMap<String, Set<TestMethod>> = hashMapOf()
@@ -35,7 +35,7 @@ fun findAllJUnit4Tests(dexFiles: List<DexFile>): List<TestMethod> {
             .flatten()
 }
 
-private fun List<DexFile>.parseClasses(): Map<String, ClassParsingResult> =
+private fun List<DexFile>.parseClasses(customAnnotations: String): Map<String, ClassParsingResult> =
         asSequence()
                 .flatMap { dexFile ->
                     // We include classes that do not have annotations because there may be an intermediary class without tests
@@ -48,7 +48,7 @@ private fun List<DexFile>.parseClasses(): Map<String, ClassParsingResult> =
                             .map { classDef ->
                                 val testMethods = dexFile
                                         .createTestMethods(classDef, dexFile.findMethodIds())
-                                        .filter { it.containsTestAnnotation }
+                                        .filter { it.containsTestAnnotation(customAnnotations) }
 
                                 ClassParsingResult(
                                         dexFile = dexFile,
@@ -64,8 +64,20 @@ private fun List<DexFile>.parseClasses(): Map<String, ClassParsingResult> =
 
 private const val JUNIT_TEST_ANNOTATION_NAME = "org.junit.Test"
 
-private val TestMethod.containsTestAnnotation: Boolean
-    get() = annotations.map { it.name }.contains(JUNIT_TEST_ANNOTATION_NAME)
+private fun TestMethod.containsTestAnnotation(customAnnotations: String): Boolean {
+    if (customAnnotations.length > 0) {
+        val parts = customAnnotations.split(",")
+        for (part in parts) {
+            if (annotations.map { it.name }.contains(part)) {
+                return true
+            }
+        }
+    }
+    if (annotations.map { it.name }.contains(JUNIT_TEST_ANNOTATION_NAME)) {
+        return true
+    }
+    return false
+}
 
 /**
  * Find methodIds we care about: any method in the class which is annotated

--- a/parser/src/test/kotlin/com/linkedin/dex/AbstractClassInSecondDex.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/AbstractClassInSecondDex.kt
@@ -30,7 +30,7 @@ class AbstractClassInSecondDex {
     @Test
     fun parseMethodFromBaseAbstractClass_whenAbstractClassInTheSecondDex() {
         val testMethods = DexParser
-            .findTestMethods(APK_PATH)
+            .findTestMethods(APK_PATH, "")
             .filter { it.testName == "com.linkedin.parser.test.junit4.java.BasicJUnit4#abstractTest" }
 
         assertEquals(1, testMethods.size)
@@ -39,7 +39,7 @@ class AbstractClassInSecondDex {
     @Test
     fun parseMethodFromConcreteClassThatExtendsFromAbstract_whenAbstractClassInTheSecondDex() {
         val testMethods = DexParser
-            .findTestMethods(APK_PATH)
+            .findTestMethods(APK_PATH, "")
             .filter { it.testName == "com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest" }
 
         assertEquals(1, testMethods.size)

--- a/parser/src/test/kotlin/com/linkedin/dex/AbstractClassInSecondDex.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/AbstractClassInSecondDex.kt
@@ -30,7 +30,7 @@ class AbstractClassInSecondDex {
     @Test
     fun parseMethodFromBaseAbstractClass_whenAbstractClassInTheSecondDex() {
         val testMethods = DexParser
-            .findTestMethods(APK_PATH, "")
+            .findTestMethods(APK_PATH, listOf(""))
             .filter { it.testName == "com.linkedin.parser.test.junit4.java.BasicJUnit4#abstractTest" }
 
         assertEquals(1, testMethods.size)
@@ -39,7 +39,7 @@ class AbstractClassInSecondDex {
     @Test
     fun parseMethodFromConcreteClassThatExtendsFromAbstract_whenAbstractClassInTheSecondDex() {
         val testMethods = DexParser
-            .findTestMethods(APK_PATH, "")
+            .findTestMethods(APK_PATH, listOf(""))
             .filter { it.testName == "com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest" }
 
         assertEquals(1, testMethods.size)

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -17,14 +17,14 @@ class DexParserShould {
 
     @Test
     fun parseCorrectNumberOfTestMethods() {
-        val testMethods = DexParser.findTestNames(APK_PATH, "")
+        val testMethods = DexParser.findTestNames(APK_PATH, listOf(""))
 
         assertEquals(21, testMethods.size)
     }
 
     @Test
     fun parseMethodWithMultipleMethodAnnotations() {
-        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
+        val testMethods = DexParser.findTestMethods(APK_PATH, listOf("")).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
 
         assertEquals(4, testMethods.size)
 
@@ -36,7 +36,7 @@ class DexParserShould {
 
     @Test
     fun parseMethodWithChildclassAnnotation() {
-        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
+        val testMethods = DexParser.findTestMethods(APK_PATH, listOf("")).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#abstractTest", method.testName)
@@ -45,7 +45,7 @@ class DexParserShould {
 
     @Test
     fun parseInheritedMethodAnnotation() {
-        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
+        val testMethods = DexParser.findTestMethods(APK_PATH, listOf("")).filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
@@ -54,7 +54,7 @@ class DexParserShould {
 
     @Test
     fun parsNonInheritedMethodAnnotation() {
-        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
+        val testMethods = DexParser.findTestMethods(APK_PATH, listOf("")).filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
@@ -63,7 +63,7 @@ class DexParserShould {
 
     @Test
     fun parseInheritedClassAnnotation() {
-        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
+        val testMethods = DexParser.findTestMethods(APK_PATH, listOf("")).filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
@@ -222,7 +222,7 @@ class DexParserShould {
     }
 
     private fun getBasicJunit4TestMethod(): TestMethod {
-        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4") }
+        val testMethods = DexParser.findTestMethods(APK_PATH, listOf("")).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4") }
 
         assertEquals(1, testMethods.size)
 
@@ -233,7 +233,7 @@ class DexParserShould {
     }
 
     private fun getSecondBasicJunit4TestMethod(): TestMethod {
-        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second") }
+        val testMethods = DexParser.findTestMethods(APK_PATH, listOf("")).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second") }
 
         assertEquals(1, testMethods.size)
 

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -17,14 +17,14 @@ class DexParserShould {
 
     @Test
     fun parseCorrectNumberOfTestMethods() {
-        val testMethods = DexParser.findTestNames(APK_PATH)
+        val testMethods = DexParser.findTestNames(APK_PATH, "")
 
         assertEquals(21, testMethods.size)
     }
 
     @Test
     fun parseMethodWithMultipleMethodAnnotations() {
-        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
+        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
 
         assertEquals(4, testMethods.size)
 
@@ -36,7 +36,7 @@ class DexParserShould {
 
     @Test
     fun parseMethodWithChildclassAnnotation() {
-        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
+        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#abstractTest", method.testName)
@@ -45,7 +45,7 @@ class DexParserShould {
 
     @Test
     fun parseInheritedMethodAnnotation() {
-        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
+        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
@@ -54,7 +54,7 @@ class DexParserShould {
 
     @Test
     fun parsNonInheritedMethodAnnotation() {
-        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
+        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
@@ -63,7 +63,7 @@ class DexParserShould {
 
     @Test
     fun parseInheritedClassAnnotation() {
-        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
+        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("InheritedAnnotation") }.isNotEmpty() }
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
@@ -222,7 +222,7 @@ class DexParserShould {
     }
 
     private fun getBasicJunit4TestMethod(): TestMethod {
-        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4") }
+        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4") }
 
         assertEquals(1, testMethods.size)
 
@@ -233,7 +233,7 @@ class DexParserShould {
     }
 
     private fun getSecondBasicJunit4TestMethod(): TestMethod {
-        val testMethods = DexParser.findTestMethods(APK_PATH).filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second") }
+        val testMethods = DexParser.findTestMethods(APK_PATH, "").filter { it.annotations.filter { it.name.contains("TestValueAnnotation") }.isNotEmpty() }.filter { it.testName.equals("com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second") }
 
         assertEquals(1, testMethods.size)
 
@@ -328,7 +328,6 @@ class DexParserShould {
             throw Exception("Value was not an array value")
         }
     }
-
 
     // endregion
 }


### PR DESCRIPTION
Some tests are using custom runners and absolute most of them extends JUnit4 class
so they can be parsed by JUnit4 parser. The problem comes when custom runner is using
custom annotation for tests like @ScreenshotTest or @CombinatorTest. Although JUnit4
parser can see test classes and methods it filters them out because they don't have
org.junit.Test annotation.

This diff adds optional argument to the parser - customAnnotations. It is a comma-separated
string that should contain custom annotations that annotates the tests in the dex file.
Without an argument parser will look for org.junit.Test annotation as it was before.
With customAnnotations argument it will try each annotation from the list and if it's present
returns true.

Tests:
Custom annotation:
```
crazyformat@crazyformat-mbp:~/work/tests$ java -jar parser-2.2.2-SNAPSHOT.jar widget-apk.apk output/ com.company.testing.uitest.screenshot.ScreenshotTest
crazyformat@crazyformat-mbp:~/work/tests$ cat output/AllTests.txt
com.company.litho.widget.ImageScreenshotTest#testImageCenterCrop
com.company.litho.widget.ImageScreenshotTest#testImageCenterInside
com.company.litho.widget.ImageScreenshotTest#testImageFitCenter
com.company.litho.widget.ImageScreenshotTest#testImageFitXY
com.company.litho.widget.ImageScreenshotTest#testImageWithColorDrawable
com.company.litho.widget.SolidColorScreenshotTest#testAlphaColor
com.company.litho.widget.SolidColorScreenshotTest#testSolidColor
com.company.litho.widget.SpinnerScreenShotTest#testCustomCaret
com.company.litho.widget.SpinnerScreenShotTest#testEmpty
com.company.litho.widget.SpinnerScreenShotTest#testListOfFour
com.company.litho.widget.SpinnerScreenShotTest#testRedTextWithSize10Sp
com.company.litho.widget.SpinnerScreenShotTest#testShowExpandedCaretState
com.company.litho.widget.TextScreenshotTest#testText
com.company.litho.widget.TextScreenshotTest#testTextColor
com.company.litho.widget.TextScreenshotTest#testTextDifferentSizeText
com.company.litho.widget.TextScreenshotTest#testTextEllipsize
com.company.litho.widget.TextScreenshotTest#testTextLineHeight
com.company.litho.widget.TextScreenshotTest#testTextLineHeightMinLines
com.company.litho.widget.TextScreenshotTest#testTextMinAndMaxLines
com.company.litho.widget.TextScreenshotTest#testTextMinLines
com.company.litho.widget.TextScreenshotTest#testTextMultipleLines
com.company.litho.widget.TextScreenshotTest#testTextShadow
com.company.litho.widget.TextScreenshotTest#testTextSingleLine
```

another custom annotation:
```
crazyformat@crazyformat-mbp:~/work/tests$ java -jar parser-2.2.2-SNAPSHOT.jar view-apk.apk output/ com.company.combinator.CombinatorTest
crazyformat@crazyformat-mbp:~/work/tests$ cat output/AllTests.txt
com.company.inspiration.common.effects.tray.view.EffectMediaComponentSpecSnapshotTest#combinatorTest
com.company.inspiration.common.effects.tray.view.EffectsTraySectionSpecSnapshotTest#testEffectTrayCombinations
com.company.inspiration.common.effects.tray.view.InspirationEffectsTraySpecScreenshotTest#testEffectTrayCombinations
```

simple JUnit test, no custom annotations
```
crazyformat@crazyformat-mbp:~/work/tests$ java -jar parser-2.2.2-SNAPSHOT.jar activity-apk.apk output/
crazyformat@crazyformat-mbp:~/work/tests$ cat output/AllTests.txt
com.company.base.activity.FbFragmentActivityTest#testCreation
com.company.base.activity.FbFragmentActivityTest#testPreconditions
com.company.base.activity.FbPreferenceActivityTest#testCreation
```