### PR TITLE
Add @JvmOverloads to DexParser entry points

### DIFF
--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
@@ -44,11 +44,11 @@ class DexParserArgs(parser: ArgParser) {
         fun main(vararg args: String) {
             val parsedArgs = ArgParser(args).parseInto(::DexParserArgs)
             parsedArgs.run {
-                val allItems = Companion.findTestNames(apkPath, customAnnotations)
+                val allItems = findTestNames(apkPath, customAnnotations)
                 if (outputDir.isEmpty()) {
                     println(allItems.joinToString(separator = "\n"))
                 } else {
-                    Files.write(File(outputDir + "/AllTests.txt").toPath(), allItems)
+                    Files.write(File("$outputDir/AllTests.txt").toPath(), allItems)
                 }
             }
         }
@@ -57,7 +57,8 @@ class DexParserArgs(parser: ArgParser) {
          * Parse the apk found at [apkPath] and return the list of test names found in the apk
          */
         @JvmStatic
-        fun findTestNames(apkPath: String, customAnnotations: List<String>): List<String> {
+        @JvmOverloads
+        fun findTestNames(apkPath: String, customAnnotations: List<String> = emptyList()): List<String> {
             return findTestMethods(apkPath, customAnnotations).map { it.testName }
         }
 
@@ -68,7 +69,8 @@ class DexParserArgs(parser: ArgParser) {
          * explicitly applied to the test method.
          */
         @JvmStatic
-        fun findTestMethods(apkPath: String, customAnnotations: List<String>): List<TestMethod> {
+        @JvmOverloads
+        fun findTestMethods(apkPath: String, customAnnotations: List<String> = emptyList()): List<TestMethod> {
             val dexFiles = readDexFiles(apkPath)
 
             val junit3Items = findJUnit3Tests(dexFiles).sorted()


### PR DESCRIPTION
PR #50 tried to maintain backwards compatibility while adding support
for passing custom test annotations, and it did successfully do this for
the CLI case where the dex-test-parser jar is executed via the main
method.

Unfortunately, it was a breaking change for the library use case, where
dex-test-parser is added as a compile dependency to a JVM project and
the direct entry points on DexParser are used. This change adds a
default value for the new customAnnotations parameter along with
@JvmOverloads for Java consumers.

I tested this fix by trying to compile an internal project that uses these 
DexParser entry points and verifying that it failed compilation on 2.2.2-SNAPSHOT,
then made this change and verified that it compiled successfully.
