### PR TITLE
Simplify merge-check caching steps

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -17,17 +17,13 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Cache Gradle Caches
+      - name: Cache Gradle Files
         uses: actions/cache@v2
         with:
-          path: ~/.gradle/caches/
-          key: cache-gradle-cache
-
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper/
-          key: cache-gradle-wrapper
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-files
 
       - name: Run Gradle tasks
         run: ./gradlew build


### PR DESCRIPTION
Use one step with multiple paths for caching Gradle files.