### PR TITLE
Use signing.required API instead of if condition

### DIFF
--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -122,11 +122,8 @@ publishing {
 // It can be obtained with gpg --armour --export-secret-keys KEY_ID
 def signingKey = System.getenv("DEX_TEST_PARSER_GPG_PRIVATE_KEY")
 def signingPassword = System.getenv("DEX_TEST_PARSER_GPG_PRIVATE_KEY_PASSWORD")
-if (signingKey != null && signingPassword != null) {
-    signing {
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign publishing.publications.maven
-    }
-} else {
-    logger.info("Signing disabled - GPG key was not found")
+signing {
+    required { signingKey != null && signingPassword != null }
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications.maven
 }


### PR DESCRIPTION
This has the advantage that if there is an error introduced in the
signing configuration, it will still be caught locally at Gradle
configuration time. With the old version of the code, Gradle syntax
errors would never be noticed in local development because code inside
the if statement would never be executed.