### PR TITLE
Update Dokka to 1.4.32

### DIFF
--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'org.jetbrains.kotlin.jvm'
-    id 'org.jetbrains.dokka' version '1.4.20'
+    id 'org.jetbrains.dokka' version '1.4.32'
     id 'com.github.johnrengelman.shadow' version '6.1.0'
 }
 


### PR DESCRIPTION
This version updates to a newer version of a transitive dependency to be
able to pull it from Maven Central instead of JCenter, which fixes the
failed snapshot publishing after #63