### PR TITLE
fix issue with callable references in kotlin 1.4

### DIFF
--- a/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/DexParser.kt
@@ -87,7 +87,7 @@ private class DexParserCommand : CliktCommand() {
                         .filter { it.name.endsWith(".dex") }
                         .map { zip.readBytes() }
                         .map { ByteBuffer.wrap(it) }
-                        .map(::DexFile)
+                        .map { DexFile(it) }
                         .toList()
             }
         }

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
@@ -44,7 +44,7 @@ private fun List<DexFile>.parseClasses(customAnnotations: List<String>): Map<Str
                     dexFile
                             .classDefs
                             .asSequence()
-                            .filterNot(ClassDefItem::isInterface)
+                            .filterNot { classDefItem -> classDefItem.isInterface }
                             .map { classDef ->
                                 val testMethods = dexFile
                                         .createTestMethods(classDef, dexFile.findMethodIds())

--- a/parser/src/main/kotlin/com/linkedin/dex/spec/DexFile.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/spec/DexFile.kt
@@ -34,12 +34,12 @@ class DexFile(byteBuffer: ByteBuffer) {
         this.byteBuffer.position(0)
         headerItem = HeaderItem(this.byteBuffer)
         headerItem.validate()
-        stringIds = parse(headerItem.stringIdsSize, headerItem.stringIdsOff, StringIdItem.size, ::StringIdItem)
-        typeIds = parse(headerItem.typeIdsSize, headerItem.typeIdsOff, TypeIdItem.size, ::TypeIdItem)
-        protoIds = parse(headerItem.protoIdsSize, headerItem.protoIdsOff, ProtoIdItem.size, ::ProtoIdItem)
-        fieldIds = parse(headerItem.fieldIdsSize, headerItem.fieldIdsOff, FieldIdItem.size, ::FieldIdItem)
-        methodIds = parse(headerItem.methodIdsSize, headerItem.methodIdsOff, MethodIdItem.size, ::MethodIdItem)
-        classDefs = parse(headerItem.classDefsSize, headerItem.classDefsOff, ClassDefItem.size, ::ClassDefItem)
+        stringIds = parse(headerItem.stringIdsSize, headerItem.stringIdsOff, StringIdItem.size) { StringIdItem(it) }
+        typeIds = parse(headerItem.typeIdsSize, headerItem.typeIdsOff, TypeIdItem.size) { TypeIdItem(it) }
+        protoIds = parse(headerItem.protoIdsSize, headerItem.protoIdsOff, ProtoIdItem.size) { ProtoIdItem(it) }
+        fieldIds = parse(headerItem.fieldIdsSize, headerItem.fieldIdsOff, FieldIdItem.size) { FieldIdItem(it) }
+        methodIds = parse(headerItem.methodIdsSize, headerItem.methodIdsOff, MethodIdItem.size) { MethodIdItem(it) }
+        classDefs = parse(headerItem.classDefsSize, headerItem.classDefsOff, ClassDefItem.size) { ClassDefItem(it) }
     }
 
     val inheritedAnnotationTypeIdIndex: Int? by lazy {


### PR DESCRIPTION
With kotlin 1.4 many users are seeing runtime issues with callable references. Specifically for us its in a gradle plugin that fails with the new 1.4 optimizations @see https://youtrack.jetbrains.com/issue/KT-37435 and https://youtrack.jetbrains.com/issue/KT-39389. I added a change to remove the callable references and replaced them with lambdas which fixes the problem.