### PR TITLE
Parse additional dex files created in uncommon way

### DIFF
--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit3Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit3Extensions.kt
@@ -65,7 +65,7 @@ private fun findJUnit3Tests(dexFiles: List<DexFile>, testNames: MutableSet<TestM
 private fun DexFile.findJUnit3Tests(descriptors: MutableSet<String>): List<TestMethod> {
     val testClasses = findClassesWithSuperClass(descriptors)
     return createTestMethods(testClasses, { classDef, _ -> findMethodIds(classDef) })
-            .filter { it.testName.contains("#test") }
+            .filter { it.testName.contains("#test") and !it.testName.contains("#testFoo") }
 }
 
 fun DexFile.findMethodIds(classDefItem: ClassDefItem): MutableList<MethodIdItem> {

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit3Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit3Extensions.kt
@@ -65,7 +65,7 @@ private fun findJUnit3Tests(dexFiles: List<DexFile>, testNames: MutableSet<TestM
 private fun DexFile.findJUnit3Tests(descriptors: MutableSet<String>): List<TestMethod> {
     val testClasses = findClassesWithSuperClass(descriptors)
     return createTestMethods(testClasses, { classDef, _ -> findMethodIds(classDef) })
-            .filter { it.testName.contains("#test") and !it.testName.contains("#testFoo") }
+            .filter { it.testName.contains("#test") and !it.testName.endsWith("#testFoo") }
 }
 
 fun DexFile.findMethodIds(classDefItem: ClassDefItem): MutableList<MethodIdItem> {


### PR DESCRIPTION
    One build tool - Buck (http://buck.build) is using uncommon approach for multidex. It is packing
    additional dex files not as classesX.dex but as a pack of .jar files in assets/secondary-program-dex-jars.
    This diff adds support for this approach allowing parsing of these files along with common classesX.dex.

    Minors:
     - no need to print non-unique test names. This should not happen in common but some apks somehow have it
     - filter out common example test name "testFoo"