### PR TITLE
Differentiate overridden vs inherited super test methods

### DIFF
--- a/parser/ValidTestList.txt
+++ b/parser/ValidTestList.txt
@@ -11,8 +11,10 @@ com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4
 com.linkedin.parser.test.junit4.java.BasicJUnit4#basicJUnit4Second
 com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest
 com.linkedin.parser.test.junit4.java.BasicJUnit4#customAnnotationTest
+com.linkedin.parser.test.junit4.java.BasicJUnit4#nonOverriddenConcreteTest
 com.linkedin.parser.test.junit4.java.ConcreteTest#abstractTest
 com.linkedin.parser.test.junit4.java.ConcreteTest#concreteTest
+com.linkedin.parser.test.junit4.java.ConcreteTest#nonOverriddenConcreteTest
 com.linkedin.parser.test.junit4.java.JUnit4ClassInsideInterface$InnerClass#innerClassTest
 com.linkedin.parser.test.junit4.java.JUnit4TestInsideStaticInnerClass$InnerClass#innerClassTest
 com.linkedin.parser.test.junit4.kotlin.DefaultInterfaceImplementation#testMethodShouldNotBeReported

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -42,7 +42,7 @@ task testParsing(dependsOn: ':test-app:assembleDebugAndroidTest', type: JavaExec
         def parsedTests = file("$buildDir/AllTests.txt").readLines()
 
         if (validTests != parsedTests) {
-            throw new GradleException("Parsed tests do not match expected tests")
+            throw new GradleException("Parsed tests do not match expected tests: " + parsedTests)
         }
     }
 }

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
@@ -140,7 +140,7 @@ private fun createAllTestMethods(
                     .toSet()
 
             // alter the existing test methods to include super annotations if they're inherited
-            val alteredMethodsd = parsingResult.testMethods.filter { method -> superTestMethods.any {
+            val alteredMethods = parsingResult.testMethods.filter { method -> superTestMethods.any {
                 it.testNameWithoutClass == method.testNameWithoutClass
             } }
                 .map { method ->
@@ -157,7 +157,7 @@ private fun createAllTestMethods(
                 it.testNameWithoutClass == method.testNameWithoutClass
             } }
 
-            return adaptedSuperMethods union alteredMethodsd union originalTestMethods
+            return adaptedSuperMethods union alteredMethods union originalTestMethods
         }
 
 private val TestMethod.testNameWithoutClass

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/JUnit4Extensions.kt
@@ -125,7 +125,8 @@ private fun createAllTestMethods(
             // So, we exclude any that have overridden versions
             val adaptedSuperMethods = superTestMethods
                 .filterNot { superMethod -> parsingResult.testMethods.any {
-                    it.testNameWithoutClass.equals(superMethod.testNameWithoutClass) } }
+                    it.testNameWithoutClass == superMethod.testNameWithoutClass
+                } }
                     .map { method ->
                         val onlyParentAnnotations = method
                                 .annotations
@@ -139,8 +140,9 @@ private fun createAllTestMethods(
                     .toSet()
 
             // alter the existing test methods to include super annotations if they're inherited
-            parsingResult.testMethods.filter { method -> superTestMethods.any {
-            it.testNameWithoutClass.equals(method.testNameWithoutClass) } }
+            val alteredMethodsd = parsingResult.testMethods.filter { method -> superTestMethods.any {
+                it.testNameWithoutClass == method.testNameWithoutClass
+            } }
                 .map { method ->
                     val superMethod = superTestMethods.find { it.testNameWithoutClass == method.testNameWithoutClass }
                     val onlyParentAnnotations = superMethod?.annotations ?: emptySet()
@@ -148,11 +150,14 @@ private fun createAllTestMethods(
                         .filterNot { childClassAnnotationNames.contains(it.name) }
                         .filter { it.inherited }
 
-                    method.annotations += inheritedAnnotations
-
+                    TestMethod(method.testName, inheritedAnnotations + method.annotations)
                 }
 
-            return adaptedSuperMethods union parsingResult.testMethods
+            val originalTestMethods = parsingResult.testMethods.filterNot { method -> superTestMethods.any {
+                it.testNameWithoutClass == method.testNameWithoutClass
+            } }
+
+            return adaptedSuperMethods union alteredMethodsd union originalTestMethods
         }
 
 private val TestMethod.testNameWithoutClass

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/TestMethod.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/TestMethod.kt
@@ -9,7 +9,7 @@ import com.linkedin.dex.spec.ClassDefItem
 import com.linkedin.dex.spec.DexFile
 import com.linkedin.dex.spec.MethodIdItem
 
-data class TestMethod(val testName: String, val annotations: MutableList<TestAnnotation>) : Comparable<TestMethod> {
+data class TestMethod(val testName: String, val annotations: List<TestAnnotation>) : Comparable<TestMethod> {
     override fun compareTo(other: TestMethod): Int = testName.compareTo(other.testName)
 }
 

--- a/parser/src/main/kotlin/com/linkedin/dex/parser/TestMethod.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/TestMethod.kt
@@ -9,7 +9,7 @@ import com.linkedin.dex.spec.ClassDefItem
 import com.linkedin.dex.spec.DexFile
 import com.linkedin.dex.spec.MethodIdItem
 
-data class TestMethod(val testName: String, val annotations: List<TestAnnotation>) : Comparable<TestMethod> {
+data class TestMethod(val testName: String, val annotations: MutableList<TestAnnotation>) : Comparable<TestMethod> {
     override fun compareTo(other: TestMethod): Int = testName.compareTo(other.testName)
 }
 
@@ -52,7 +52,7 @@ private fun DexFile.createTestMethod(methodId: MethodIdItem,
                                      classAnnotations: List<TestAnnotation>): TestMethod {
     val methodAnnotationDescriptors = getMethodAnnotationValues(methodId, directory)
 
-    val annotations = classAnnotations.plus(methodAnnotationDescriptors)
+    val annotations = classAnnotations.plus(methodAnnotationDescriptors).toMutableList()
 
     val className = formatClassName(classDef)
     val methodName = ParseUtils.parseMethodName(byteBuffer, stringIds, methodId)

--- a/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
+++ b/parser/src/test/kotlin/com/linkedin/dex/DexParserShould.kt
@@ -49,7 +49,7 @@ class DexParserShould {
 
         val method = testMethods[0]
         assertEquals("com.linkedin.parser.test.junit4.java.BasicJUnit4#concreteTest", method.testName)
-        assertEquals(method.annotations[0].values["stringValue"], DecodedValue.DecodedString("Hello world!"))
+        assertEquals(method.annotations[2].values["stringValue"], DecodedValue.DecodedString("Hello world!"))
     }
 
     @Test

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/BasicJUnit4.java
@@ -31,6 +31,12 @@ public class BasicJUnit4 extends ConcreteTest {
         assertTrue(true);
     }
 
+    @Override
+    @Test
+    public void concreteTest() {
+        super.concreteTest();
+    }
+
     @NonInheritedAnnotation
     public void customAnnotationTest() {
 

--- a/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/ConcreteTest.java
+++ b/test-app/src/androidTest/java/com/linkedin/parser/test/junit4/java/ConcreteTest.java
@@ -13,4 +13,11 @@ public class ConcreteTest extends AbstractTest {
     public void concreteTest() {
         assertTrue(true);
     }
+
+    @NonInheritedAnnotation
+    @InheritedAnnotation
+    @Test
+    public void nonOverriddenConcreteTest() {
+        assertTrue(true);
+    }
 }


### PR DESCRIPTION
There is a behavior difference betweeen the case of a superclass test method
that is not overridden by the subclass, and one that is - when it is not overridden,
the actual super method is used, and so all of its annotations remain in tact. However
when it _is_ overridden, only inherited annotations are retained. This adds support for
handling this difference by splitting the cases when parsing.

Also updated tests to be more robust, there were some noticeable gaps.

Fixes #69