### PR TITLE
Fix BufferUnderflowException when parsing dex file with Espresso 3.4.0 Fixes #72

### DIFF
--- a/parser/src/main/kotlin/com/linkedin/dex/parser/AnnotationUtils.kt
+++ b/parser/src/main/kotlin/com/linkedin/dex/parser/AnnotationUtils.kt
@@ -85,7 +85,7 @@ private fun DexFile.checkIfAnnotationIsInherited(annotationClassDef: ClassDefIte
 
     return annotationClassDef?.let {
         val annotationsDirectory = getAnnotationsDirectory(annotationClassDef)
-        if (annotationsDirectory != null) {
+        if (annotationsDirectory != null && annotationsDirectory.classAnnotationsOff != 0) {
             val classAnnotationSetItem = AnnotationSetItem.create(byteBuffer, annotationsDirectory.classAnnotationsOff)
             val annotations = classAnnotationSetItem.entries.map { AnnotationItem.create(byteBuffer, it.annotationOff) }
             return@let annotations.any { it.encodedAnnotation.typeIdx == inheritedAnnotationTypeIdIndex }


### PR DESCRIPTION
`classAnnotationsOff` can be 0 according to [this](https://source.android.com/devices/tech/dalvik/dex-format#annotations-directory). Missing this check causes the crash in #72.

> class_annotations_off
> offset from the start of the file to the annotations made directly on the class, or 0 if the class has no direct annotations. The offset, if non-zero, should be to a location in the data section. The format of the data is specified by "annotation_set_item" below. 